### PR TITLE
Add missing JSDoc namespaces.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,15 @@
 /**
  * @namespace google.cloud.automl.v1beta1
  */
+/**
+ * @namespace google.longrunning
+ */
+/**
+ * @namespace google.protobuf
+ */
+/**
+ * @namespace google.rpc
+ */
 
 'use strict';
 


### PR DESCRIPTION
A new release needs to be cut for these changes to be able to fix the generated JSDocs.