### PR TITLE
feat: support new AutoML problems; add batchPredict, exportModel methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 *.lock
 .DS_Store
 package-lock.json
+__pycache__

--- a/protos/google/cloud/automl/v1beta1/annotation_payload.proto
+++ b/protos/google/cloud/automl/v1beta1/annotation_payload.proto
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
 syntax = "proto3";
 
@@ -18,23 +19,45 @@ package google.cloud.automl.v1beta1;
 
 import "google/api/annotations.proto";
 import "google/cloud/automl/v1beta1/classification.proto";
+import "google/cloud/automl/v1beta1/detection.proto";
+import "google/cloud/automl/v1beta1/tables.proto";
+import "google/cloud/automl/v1beta1/text_extraction.proto";
+import "google/cloud/automl/v1beta1/text_sentiment.proto";
 import "google/cloud/automl/v1beta1/translation.proto";
+import "google/protobuf/any.proto";
 
 option go_package = "google.golang.org/genproto/googleapis/cloud/automl/v1beta1;automl";
 option java_multiple_files = true;
 option java_package = "com.google.cloud.automl.v1beta1";
 option php_namespace = "Google\\Cloud\\AutoMl\\V1beta1";
 
+
 // Contains annotation information that is relevant to AutoML.
 message AnnotationPayload {
   // Output only . Additional information about the annotation
-  // specific to the AutoML solution.
+  // specific to the AutoML domain.
   oneof detail {
     // Annotation details for translation.
     TranslationAnnotation translation = 2;
 
     // Annotation details for content or image classification.
     ClassificationAnnotation classification = 3;
+
+    // Annotation details for image object detection.
+    ImageObjectDetectionAnnotation image_object_detection = 4;
+
+    // Annotation details for video classification.
+    // Returned for Video Classification predictions.
+    VideoClassificationAnnotation video_classification = 9;
+
+    // Annotation details for text extraction.
+    TextExtractionAnnotation text_extraction = 6;
+
+    // Annotation details for text sentiment.
+    TextSentimentAnnotation text_sentiment = 7;
+
+    // Annotation details for Tables.
+    TablesAnnotation tables = 10;
   }
 
   // Output only . The resource ID of the annotation spec that
@@ -42,11 +65,10 @@ message AnnotationPayload {
   // ancestor dataset, or the dataset that was used to train the model in use.
   string annotation_spec_id = 1;
 
-  // Output only. The value of
-  // [AnnotationSpec.display_name][google.cloud.automl.v1beta1.AnnotationSpec.display_name]
-  // when the model was trained. Because this field returns a value at model
-  // training time, for different models trained using the same dataset, the
-  // returned value could be different as model owner could update the
-  // display_name between any two model training.
+  // Output only. The value of [AnnotationSpec.display_name][google.cloud.automl.v1beta1.AnnotationSpec.display_name] when the model
+  // was trained. Because this field returns a value at model training time,
+  // for different models trained using the same dataset, the returned value
+  // could be different as model owner could update the display_name between
+  // any two model training.
   string display_name = 5;
 }

--- a/protos/google/cloud/automl/v1beta1/classification.proto
+++ b/protos/google/cloud/automl/v1beta1/classification.proto
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,17 +11,20 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
 syntax = "proto3";
 
 package google.cloud.automl.v1beta1;
 
 import "google/api/annotations.proto";
+import "google/cloud/automl/v1beta1/temporal.proto";
 
 option go_package = "google.golang.org/genproto/googleapis/cloud/automl/v1beta1;automl";
 option java_outer_classname = "ClassificationProto";
 option java_package = "com.google.cloud.automl.v1beta1";
 option php_namespace = "Google\\Cloud\\AutoMl\\V1beta1";
+
 
 // Contains annotation details specific to classification.
 message ClassificationAnnotation {
@@ -33,38 +36,102 @@ message ClassificationAnnotation {
   float score = 1;
 }
 
+// Contains annotation details specific to video classification.
+message VideoClassificationAnnotation {
+  // Output only. Expresses the type of video classification. Possible values:
+  //
+  // *  `segment` - Classification done on a specified by user
+  //        time segment of a video. AnnotationSpec is answered to be present
+  //        in that time segment, if it is present in any part of it. The video
+  //        ML model evaluations are done only for this type of classification.
+  //
+  // *  `shot`- Shot-level classification.
+  //        AutoML Video Intelligence determines the boundaries
+  //        for each camera shot in the entire segment of the video that user
+  //        specified in the request configuration. AutoML Video Intelligence
+  //        then returns labels and their confidence scores for each detected
+  //        shot, along with the start and end time of the shot.
+  //        WARNING: Model evaluation is not done for this classification type,
+  //        the quality of it depends on training data, but there are no
+  //        metrics provided to describe that quality.
+  //
+  // *  `1s_interval` - AutoML Video Intelligence returns labels and their
+  //        confidence scores for each second of the entire segment of the video
+  //        that user specified in the request configuration.
+  //        WARNING: Model evaluation is not done for this classification type,
+  //        the quality of it depends on training data, but there are no
+  //        metrics provided to describe that quality.
+  string type = 1;
+
+  // Output only . The classification details of this annotation.
+  ClassificationAnnotation classification_annotation = 2;
+
+  // Output only . The time segment of the video to which the
+  // annotation applies.
+  TimeSegment time_segment = 3;
+}
+
 // Model evaluation metrics for classification problems.
-// Visible only to v1beta1
+// Note: For Video Classification this metrics only describe quality of the
+// Video Classification predictions of "segment_classification" type.
 message ClassificationEvaluationMetrics {
   // Metrics for a single confidence threshold.
   message ConfidenceMetricsEntry {
-    // Output only. The confidence threshold value used to compute the metrics.
+    // Output only. Metrics are computed with an assumption that the model
+    // never returns predictions with score lower than this value.
     float confidence_threshold = 1;
 
-    // Output only. Recall under the given confidence threshold.
+    // Output only. Metrics are computed with an assumption that the model
+    // always returns at most this many predictions (ordered by their score,
+    // descendingly), but they all still need to meet the confidence_threshold.
+    int32 position_threshold = 14;
+
+    // Output only. Recall (True Positive Rate) for the given confidence
+    // threshold.
     float recall = 2;
 
-    // Output only. Precision under the given confidence threshold.
+    // Output only. Precision for the given confidence threshold.
     float precision = 3;
+
+    // Output only. False Positive Rate for the given confidence threshold.
+    float false_positive_rate = 8;
 
     // Output only. The harmonic mean of recall and precision.
     float f1_score = 4;
 
-    // Output only. The recall when only considering the label that has the
-    // highest prediction score and not below the confidence threshold for each
-    // example.
+    // Output only. The Recall (True Positive Rate) when only considering the
+    // label that has the highest prediction score and not below the confidence
+    // threshold for each example.
     float recall_at1 = 5;
 
     // Output only. The precision when only considering the label that has the
-    // highest predictionscore and not below the confidence threshold for each
+    // highest prediction score and not below the confidence threshold for each
     // example.
     float precision_at1 = 6;
 
-    // Output only. The harmonic mean of
-    // [recall_at1][google.cloud.automl.v1beta1.ClassificationEvaluationMetrics.ConfidenceMetricsEntry.recall_at1]
-    // and
-    // [precision_at1][google.cloud.automl.v1beta1.ClassificationEvaluationMetrics.ConfidenceMetricsEntry.precision_at1].
+    // Output only. The False Positive Rate when only considering the label that
+    // has the highest prediction score and not below the confidence threshold
+    // for each example.
+    float false_positive_rate_at1 = 9;
+
+    // Output only. The harmonic mean of [recall_at1][google.cloud.automl.v1beta1.ClassificationEvaluationMetrics.ConfidenceMetricsEntry.recall_at1] and [precision_at1][google.cloud.automl.v1beta1.ClassificationEvaluationMetrics.ConfidenceMetricsEntry.precision_at1].
     float f1_score_at1 = 7;
+
+    // Output only. The number of model created labels that match a ground truth
+    // label.
+    int64 true_positive_count = 10;
+
+    // Output only. The number of model created labels that do not match a
+    // ground truth label.
+    int64 false_positive_count = 11;
+
+    // Output only. The number of ground truth labels that are not matched
+    // by a model created label.
+    int64 false_negative_count = 12;
+
+    // Output only. The number of labels that were not created by the model,
+    // but if they would, they would not match a ground truth label.
+    int64 true_negative_count = 13;
   }
 
   // Confusion matrix of the model running the classification.
@@ -72,8 +139,8 @@ message ClassificationEvaluationMetrics {
     // Output only. A row in the confusion matrix.
     message Row {
       // Output only. Value of the specific cell in the confusion matrix.
-      // The number of values each row is equal to the size of
-      // annotatin_spec_id.
+      // The number of values each row has (i.e. the length of the row) is equal
+      // to the length of the annotation_spec_id field.
       repeated int32 example_count = 1;
     }
 
@@ -88,14 +155,28 @@ message ClassificationEvaluationMetrics {
     repeated Row row = 2;
   }
 
-  // Output only. The Area under precision recall curve metric.
+  // Output only. The Area Under Precision-Recall Curve metric. Micro-averaged
+  // for the overall evaluation.
   float au_prc = 1;
 
-  // Output only. The Area under precision recall curve metric based on priors.
-  float base_au_prc = 2;
+  // Output only. The Area Under Precision-Recall Curve metric based on priors.
+  // Micro-averaged for the overall evaluation.
+  // Deprecated.
+  float base_au_prc = 2 [deprecated = true];
 
-  // Output only. Metrics that have confidence thresholds.
-  // Precision-recall curve can be derived from it.
+  // Output only. The Area Under Receiver Operating Characteristic curve metric.
+  // Micro-averaged for the overall evaluation.
+  float au_roc = 6;
+
+  // Output only. The Log Loss metric.
+  float log_loss = 7;
+
+  // Output only. Metrics for each confidence_threshold in
+  // 0.00,0.05,0.10,...,0.95,0.96,0.97,0.98,0.99 and
+  // position_threshold = INT32_MAX_VALUE.
+  // Precision-recall curve is derived from them.
+  // The above metrics may also be supplied for additional values of
+  // position_threshold.
   repeated ConfidenceMetricsEntry confidence_metrics_entry = 3;
 
   // Output only. Confusion matrix of the evaluation.

--- a/protos/google/cloud/automl/v1beta1/column_spec.proto
+++ b/protos/google/cloud/automl/v1beta1/column_spec.proto
@@ -1,0 +1,78 @@
+// Copyright 2018 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package google.cloud.automl.v1beta1;
+
+import "google/api/annotations.proto";
+import "google/cloud/automl/v1beta1/data_stats.proto";
+import "google/cloud/automl/v1beta1/data_types.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/cloud/automl/v1beta1;automl";
+option java_multiple_files = true;
+option java_package = "com.google.cloud.automl.v1beta1";
+option php_namespace = "Google\\Cloud\\AutoMl\\V1beta1";
+
+
+// A representation of a column in a relational table. When listing them, column specs are returned in the same order in which they were
+// given on import .
+// Used by:
+//   *   Tables
+message ColumnSpec {
+  // Identifies the table's column, and its correlation with the column this
+  // ColumnSpec describes.
+  message CorrelatedColumn {
+    // The column_spec_id of the correlated column, which belongs to the same
+    // table as the in-context column.
+    string column_spec_id = 1;
+
+    // Correlation between this and the in-context column.
+    CorrelationStats correlation_stats = 2;
+  }
+
+  // Output only. The resource name of the column specs.
+  // Form:
+  //
+  // `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/tableSpecs/{table_spec_id}/columnSpecs/{column_spec_id}`
+  string name = 1;
+
+  // The data type of elements stored in the column.
+  DataType data_type = 2;
+
+  // Output only. The name of the column to show in the interface. The name can
+  // be up to 100 characters long and can consist only of ASCII Latin letters
+  // A-Z and a-z, ASCII digits 0-9, underscores(_), and forward slashes(/), and
+  // must start with a letter or a digit.
+  string display_name = 3;
+
+  // Output only. Stats of the series of values in the column.
+  // This field may be stale, see the ancestor's
+  // Dataset.tables_dataset_metadata.stats_update_time field
+  // for the timestamp at which these stats were last updated.
+  DataStats data_stats = 4;
+
+  // Output only. Top 10 most correlated with this column columns of the table,
+  // ordered by
+  // [cramers_v][google.cloud.automl.v1beta1.CorrelationStats.cramers_v] metric.
+  // This field may be stale, see the ancestor's
+  // Dataset.tables_dataset_metadata.stats_update_time field
+  // for the timestamp at which these stats were last updated.
+  repeated CorrelatedColumn top_correlated_columns = 5;
+
+  // Used to perform consistent read-modify-write updates. If not set, a blind
+  // "overwrite" update happens.
+  string etag = 6;
+}

--- a/protos/google/cloud/automl/v1beta1/data_items.proto
+++ b/protos/google/cloud/automl/v1beta1/data_items.proto
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
 syntax = "proto3";
 
@@ -18,13 +19,18 @@ package google.cloud.automl.v1beta1;
 
 import "google/api/annotations.proto";
 import "google/cloud/automl/v1beta1/io.proto";
+import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
 
 option go_package = "google.golang.org/genproto/googleapis/cloud/automl/v1beta1;automl";
 option java_multiple_files = true;
 option java_package = "com.google.cloud.automl.v1beta1";
 option php_namespace = "Google\\Cloud\\AutoMl\\V1beta1";
 
+
 // A representation of an image.
+// Only images up to 30MB in size are supported.
 message Image {
   // Input only. The data representing the image.
   // For Predict calls [image_bytes][] must be set, as other options are not
@@ -50,24 +56,54 @@ message TextSnippet {
   // characters long.
   string content = 1;
 
-  // The format of the source text. For example, "text/html" or
-  // "text/plain". If left blank the format is automatically determined from
-  // the type of the uploaded content. The default is "text/html". Up to 25000
-  // characters long.
+  // The format of the source text. Currently the only two allowed values are
+  // "text/html" and "text/plain". If left blank the format is automatically
+  // determined from the type of the uploaded content.
   string mime_type = 2;
 
   // Output only. HTTP URI where you can download the content.
   string content_uri = 4;
 }
 
+// A structured text document e.g. a PDF.
+message Document {
+  // An input config specifying the content of the document.
+  DocumentInputConfig input_config = 1;
+}
+
+// A representation of a row in a relational table.
+message Row {
+  // The resource IDs of the column specs describing the columns of the row.
+  // If set must contain, but possibly in a different order, all input feature
+  //
+  // [column_spec_ids][google.cloud.automl.v1beta1.TablesModelMetadata.input_feature_column_specs]
+  // of the Model this row is being passed to.
+  // Note: The below `values` field must match order of this field, if this
+  // field is set.
+  repeated string column_spec_ids = 2;
+
+  // Required. The values of the row cells, given in the same order as the
+  // column_spec_ids, or, if not set, then in the same order as input feature
+  //
+  // [column_specs][google.cloud.automl.v1beta1.TablesModelMetadata.input_feature_column_specs]
+  // of the Model this row is being passed to.
+  repeated google.protobuf.Value values = 3;
+}
+
 // Example data used for training or prediction.
 message ExamplePayload {
   // Required. Input only. The example data.
   oneof payload {
-    // An example image.
+    // Example image.
     Image image = 1;
 
     // Example text.
     TextSnippet text_snippet = 2;
+
+    // Example document.
+    Document document = 4;
+
+    // Example relational table row.
+    Row row = 3;
   }
 }

--- a/protos/google/cloud/automl/v1beta1/data_stats.proto
+++ b/protos/google/cloud/automl/v1beta1/data_stats.proto
@@ -1,0 +1,164 @@
+// Copyright 2018 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package google.cloud.automl.v1beta1;
+
+import "google/api/annotations.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/cloud/automl/v1beta1;automl";
+option java_multiple_files = true;
+option java_package = "com.google.cloud.automl.v1beta1";
+option php_namespace = "Google\\Cloud\\AutoMl\\V1beta1";
+
+
+// The data statistics of a series of values that share the same DataType.
+message DataStats {
+  // The data statistics specific to a DataType.
+  oneof stats {
+    // The statistics for FLOAT64 DataType.
+    Float64Stats float64_stats = 3;
+
+    // The statistics for STRING DataType.
+    StringStats string_stats = 4;
+
+    // The statistics for TIMESTAMP DataType.
+    TimestampStats timestamp_stats = 5;
+
+    // The statistics for ARRAY DataType.
+    ArrayStats array_stats = 6;
+
+    // The statistics for STRUCT DataType.
+    StructStats struct_stats = 7;
+
+    // The statistics for CATEGORY DataType.
+    CategoryStats category_stats = 8;
+  }
+
+  // The number of distinct values.
+  int64 distinct_value_count = 1;
+
+  // The number of values that are null.
+  int64 null_value_count = 2;
+}
+
+// The data statistics of a series of FLOAT64 values.
+message Float64Stats {
+  // A bucket of a histogram.
+  message HistogramBucket {
+    // The minimum value of the bucket, inclusive.
+    double min = 1;
+
+    // The maximum value of the bucket, exclusive unless max = `"Infinity"`, in
+    // which case it's inclusive.
+    double max = 2;
+
+    // The number of data values that are in the bucket, i.e. are between
+    // min and max values.
+    int64 count = 3;
+  }
+
+  // The mean of the series.
+  double mean = 1;
+
+  // The standard deviation of the series.
+  double standard_deviation = 2;
+
+  // Ordered from 0 to k k-quantile values of the data series of n values.
+  // The value at index i is, approximately, the i*n/k-th smallest value in the
+  // series; for i = 0 and i = k these are, respectively, the min and max
+  // values.
+  repeated double quantiles = 3;
+
+  // Histogram buckets of the data series. Sorted by the min value of the
+  // bucket, ascendingly, and the number of the buckets is dynamically
+  // generated. The buckets are non-overlapping and completely cover whole
+  // FLOAT64 range with min of first bucket being `"-Infinity"`, and max of
+  // the last one being `"Infinity"`.
+  repeated HistogramBucket histogram_buckets = 4;
+}
+
+// The data statistics of a series of STRING values.
+message StringStats {
+  // The statistics of a unigram.
+  message UnigramStats {
+    // The unigram.
+    string value = 1;
+
+    // The number of occurrences of this unigram in the series.
+    int64 count = 2;
+  }
+
+  // The statistics of the top 20 unigrams, ordered by
+  // [count][google.cloud.automl.v1beta1.StringStats.UnigramStats.count].
+  repeated UnigramStats top_unigram_stats = 1;
+}
+
+// The data statistics of a series of TIMESTAMP values.
+message TimestampStats {
+  // Stats split by a defined in context granularity.
+  message GranularStats {
+    // A map from granularity key to example count for that key.
+    // E.g. for hour_of_day `13` means 1pm, or for month_of_year `5` means May).
+    map<int32, int64> buckets = 1;
+  }
+
+  // The string key is the pre-defined granularity. Currently supported:
+  // hour_of_day, day_of_week, month_of_year.
+  // Granularities finer that the granularity of timestamp data are not
+  // populated (e.g. if timestamps are at day granularity, then hour_of_day
+  // is not populated).
+  map<string, GranularStats> granular_stats = 1;
+}
+
+// The data statistics of a series of ARRAY values.
+message ArrayStats {
+  // Stats of all the values of all arrays, as if they were a single long
+  // series of data. The type depends on the element type of the array.
+  DataStats member_stats = 2;
+}
+
+// The data statistics of a series of STRUCT values.
+message StructStats {
+  // Map from a field name of the struct to data stats aggregated over series
+  // of all data in that field across all the structs.
+  map<string, DataStats> field_stats = 1;
+}
+
+// The data statistics of a series of CATEGORY values.
+message CategoryStats {
+  // The statistics of a single CATEGORY value.
+  message SingleCategoryStats {
+    // The CATEGORY value.
+    string value = 1;
+
+    // The number of occurrences of this value in the series.
+    int64 count = 2;
+  }
+
+  // The statistics of the top 20 CATEGORY values, ordered by
+  //
+  // [count][google.cloud.automl.v1beta1.CategoryStats.SingleCategoryStats.count].
+  repeated SingleCategoryStats top_category_stats = 1;
+}
+
+// A correlation statistics between two series of DataType values. The series
+// may have differing DataType-s, but within a single series the DataType must
+// be the same.
+message CorrelationStats {
+  // The correlation value using the Cramer's V measure.
+  double cramers_v = 1;
+}

--- a/protos/google/cloud/automl/v1beta1/data_types.proto
+++ b/protos/google/cloud/automl/v1beta1/data_types.proto
@@ -1,0 +1,116 @@
+// Copyright 2018 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package google.cloud.automl.v1beta1;
+
+import "google/api/annotations.proto";
+import "google/cloud/automl/v1beta1/io.proto";
+import "google/cloud/automl/v1beta1/text_extraction.proto";
+import "google/protobuf/any.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/cloud/automl/v1beta1;automl";
+option java_multiple_files = true;
+option java_package = "com.google.cloud.automl.v1beta1";
+option php_namespace = "Google\\Cloud\\AutoMl\\V1beta1";
+
+
+// Indicated the type of data that can be stored in a structured data entity
+// (e.g. a table).
+message DataType {
+  // Details of DataType-s that need additional specification.
+  oneof details {
+    // If [type_code][google.cloud.automl.v1beta1.DataType.type_code] == [ARRAY][google.cloud.automl.v1beta1.TypeCode.ARRAY],
+    // then `list_element_type` is the type of the elements.
+    DataType list_element_type = 2;
+
+    // If [type_code][google.cloud.automl.v1beta1.DataType.type_code] == [STRUCT][google.cloud.automl.v1beta1.TypeCode.STRUCT], then `struct_type`
+    // provides type information for the struct's fields.
+    StructType struct_type = 3;
+
+    // If [type_code][google.cloud.automl.v1beta1.DataType.type_code] == [TIMESTAMP][google.cloud.automl.v1beta1.TypeCode.TIMESTAMP]
+    // then `time_format` provides the format in which that time field is
+    // expressed. The time_format must either be one of:
+    // * `UNIX_SECONDS`
+    // * `UNIX_MILLISECONDS`
+    // * `UNIX_MICROSECONDS`
+    // * `UNIX_NANOSECONDS`
+    // (for respectively number of seconds, milliseconds, microseconds and
+    // nanoseconds since start of the Unix epoch);
+    // or be written in `strftime` syntax. If time_format is not set, then the
+    // default format as described on the type_code is used.
+    string time_format = 5;
+  }
+
+  // Required. The [TypeCode][google.cloud.automl.v1beta1.TypeCode] for this type.
+  TypeCode type_code = 1;
+
+  // If true, this DataType can also be `null`.
+  bool nullable = 4;
+}
+
+// `StructType` defines the DataType-s of a [STRUCT][google.cloud.automl.v1beta1.TypeCode.STRUCT] type.
+message StructType {
+  // Unordered map of struct field names to their data types.
+  // Fields cannot be added or removed via Update. Their names and
+  // data types are still mutable.
+  map<string, DataType> fields = 1;
+}
+
+// `TypeCode` is used as a part of
+// [DataType][google.cloud.automl.v1beta1.DataType].
+//
+// Each legal value of a DataType can be encoded to or decoded from a JSON
+// value, using the encodings listed below, and definitions of which can be
+// found at
+//
+// https:
+// //developers.google.com/protocol-buffers
+// // /docs/reference/google.protobuf#value.
+enum TypeCode {
+  // Not specified. Should not be used.
+  TYPE_CODE_UNSPECIFIED = 0;
+
+  // Encoded as `number`, or the strings `"NaN"`, `"Infinity"`, or
+  // `"-Infinity"`.
+  FLOAT64 = 3;
+
+  // Must be between 0AD and 9999AD. Encoded as `string` according to
+  // [time_format][google.cloud.automl.v1beta1.DataType.time_format], or, if
+  // that format is not set, then in RFC 3339 `date-time` format, where
+  // `time-offset` = `"Z"` (e.g. 1985-04-12T23:20:50.52Z).
+  TIMESTAMP = 4;
+
+  // Encoded as `string`.
+  STRING = 6;
+
+  // Encoded as `list`, where the list elements are represented according to
+  //
+  // [list_element_type][google.cloud.automl.v1beta1.DataType.list_element_type].
+  ARRAY = 8;
+
+  // Encoded as `struct`, where field values are represented according to
+  // [struct_type][google.cloud.automl.v1beta1.DataType.struct_type].
+  STRUCT = 9;
+
+  // Values of this type are not further understood by AutoML,
+  // e.g. AutoML is unable to tell the order of values (as it could with
+  // FLOAT64), or is unable to say if one value contains another (as it
+  // could with STRING).
+  // Encoded as `string` (bytes should be base64-encoded, as described in RFC
+  // 4648, section 4).
+  CATEGORY = 10;
+}

--- a/protos/google/cloud/automl/v1beta1/dataset.proto
+++ b/protos/google/cloud/automl/v1beta1/dataset.proto
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
 syntax = "proto3";
 
@@ -20,14 +21,17 @@ import "google/api/annotations.proto";
 import "google/cloud/automl/v1beta1/annotation_payload.proto";
 import "google/cloud/automl/v1beta1/data_items.proto";
 import "google/cloud/automl/v1beta1/image.proto";
+import "google/cloud/automl/v1beta1/tables.proto";
 import "google/cloud/automl/v1beta1/text.proto";
 import "google/cloud/automl/v1beta1/translation.proto";
+import "google/cloud/automl/v1beta1/video.proto";
 import "google/protobuf/timestamp.proto";
 
 option go_package = "google.golang.org/genproto/googleapis/cloud/automl/v1beta1;automl";
 option java_multiple_files = true;
 option java_package = "com.google.cloud.automl.v1beta1";
 option php_namespace = "Google\\Cloud\\AutoMl\\V1beta1";
+
 
 // A workspace for solving a single, particular machine learning (ML) problem.
 // A workspace contains examples that may be annotated.
@@ -39,11 +43,25 @@ message Dataset {
     TranslationDatasetMetadata translation_dataset_metadata = 23;
 
     // Metadata for a dataset used for image classification.
-    ImageClassificationDatasetMetadata image_classification_dataset_metadata =
-        24;
+    ImageClassificationDatasetMetadata image_classification_dataset_metadata = 24;
 
     // Metadata for a dataset used for text classification.
     TextClassificationDatasetMetadata text_classification_dataset_metadata = 25;
+
+    // Metadata for a dataset used for image object detection.
+    ImageObjectDetectionDatasetMetadata image_object_detection_dataset_metadata = 26;
+
+    // Metadata for a dataset used for video classification.
+    VideoClassificationDatasetMetadata video_classification_dataset_metadata = 31;
+
+    // Metadata for a dataset used for text extraction.
+    TextExtractionDatasetMetadata text_extraction_dataset_metadata = 28;
+
+    // Metadata for a dataset used for text sentiment.
+    TextSentimentDatasetMetadata text_sentiment_dataset_metadata = 30;
+
+    // Metadata for a dataset used for Tables.
+    TablesDatasetMetadata tables_dataset_metadata = 33;
   }
 
   // Output only. The resource name of the dataset.
@@ -51,14 +69,42 @@ message Dataset {
   string name = 1;
 
   // Required. The name of the dataset to show in the interface. The name can be
-  // up to 32 characters
-  // long and can consist only of ASCII Latin letters A-Z and a-z, underscores
+  // up to 32 characters long and can consist only of ASCII Latin letters A-Z
+  // and a-z, underscores
   // (_), and ASCII digits 0-9.
   string display_name = 2;
+
+  // User-provided description of the dataset. The description can be up to
+  // 25000 characters long.
+  string description = 3;
 
   // Output only. The number of examples in the dataset.
   int32 example_count = 21;
 
   // Output only. Timestamp when this dataset was created.
   google.protobuf.Timestamp create_time = 14;
+
+  // Used to perform consistent read-modify-write updates. If not set, a blind
+  // "overwrite" update happens.
+  string etag = 17;
+}
+
+// A definition of an annotation.
+message AnnotationSpec {
+  // Output only. Resource name of the annotation spec.
+  // Form:
+  //
+  // 'projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/annotationSpecs/{annotation_spec_id}'
+  string name = 1;
+
+  // Required.
+  // The name of the annotation spec to show in the interface. The name can be
+  // up to 32 characters long and can consist only of ASCII Latin letters A-Z
+  // and a-z, underscores
+  // (_), and ASCII digits 0-9.
+  string display_name = 2;
+
+  // Output only. The number of examples in the parent dataset
+  // labeled by the annotation spec.
+  int32 example_count = 9;
 }

--- a/protos/google/cloud/automl/v1beta1/detection.proto
+++ b/protos/google/cloud/automl/v1beta1/detection.proto
@@ -1,0 +1,89 @@
+// Copyright 2018 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package google.cloud.automl.v1beta1;
+
+import "google/api/annotations.proto";
+import "google/cloud/automl/v1beta1/geometry.proto";
+import "google/protobuf/duration.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/cloud/automl/v1beta1;automl";
+option java_multiple_files = true;
+option java_package = "com.google.cloud.automl.v1beta1";
+option php_namespace = "Google\\Cloud\\AutoMl\\V1beta1";
+
+
+// Annotation details for image object detection.
+message ImageObjectDetectionAnnotation {
+  // Output only.
+  // The rectangle representing the object location.
+  BoundingPoly bounding_box = 1;
+
+  // Output only.
+  // The confidence that this annotation is positive for the parent example,
+  // value in [0, 1], higher means higher positivity confidence.
+  float score = 2;
+}
+
+// Bounding box matching model metrics for a single intersection-over-union
+// threshold and multiple label match confidence thresholds.
+message BoundingBoxMetricsEntry {
+  // Metrics for a single confidence threshold.
+  message ConfidenceMetricsEntry {
+    // Output only. The confidence threshold value used to compute the metrics.
+    float confidence_threshold = 1;
+
+    // Output only. Recall under the given confidence threshold.
+    float recall = 2;
+
+    // Output only. Precision under the given confidence threshold.
+    float precision = 3;
+
+    // Output only. The harmonic mean of recall and precision.
+    float f1_score = 4;
+  }
+
+  // Output only. The intersection-over-union threshold value used to compute
+  // this metrics entry.
+  float iou_threshold = 1;
+
+  // Output only. The mean average precision, most often close to au_prc.
+  float mean_average_precision = 2;
+
+  // Output only. Metrics for each label-match confidence_threshold from
+  // 0.05,0.10,...,0.95,0.96,0.97,0.98,0.99. Precision-recall curve is
+  // derived from them.
+  repeated ConfidenceMetricsEntry confidence_metrics_entries = 3;
+}
+
+// Model evaluation metrics for image object detection problems.
+// Evaluates prediction quality of labeled bounding boxes.
+message ImageObjectDetectionEvaluationMetrics {
+  // Output only. The total number of bounding boxes (i.e. summed over all
+  // images) the ground truth used to create this evaluation had.
+  int32 evaluated_bounding_box_count = 1;
+
+  // Output only. The bounding boxes match metrics for each
+  // Intersection-over-union threshold 0.05,0.10,...,0.95,0.96,0.97,0.98,0.99
+  // and each label confidence threshold 0.05,0.10,...,0.95,0.96,0.97,0.98,0.99
+  // pair.
+  repeated BoundingBoxMetricsEntry bounding_box_metrics_entries = 2;
+
+  // Output only. The single metric for bounding boxes evaluation:
+  // the mean_average_precision averaged over all bounding_box_metrics_entries.
+  float bounding_box_mean_average_precision = 3;
+}

--- a/protos/google/cloud/automl/v1beta1/geometry.proto
+++ b/protos/google/cloud/automl/v1beta1/geometry.proto
@@ -1,0 +1,47 @@
+// Copyright 2018 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package google.cloud.automl.v1beta1;
+
+import "google/api/annotations.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/cloud/automl/v1beta1;automl";
+option java_multiple_files = true;
+option java_package = "com.google.cloud.automl.v1beta1";
+option php_namespace = "Google\\Cloud\\AutoMl\\V1beta1";
+
+
+// A vertex represents a 2D point in the image.
+// The normalized vertex coordinates are between 0 to 1 fractions relative to
+// the original plane (image, video). E.g. if the plane (e.g. whole image) would
+// have size 10 x 20 then a point with normalized coordinates (0.1, 0.3) would
+// be at the position (1, 6) on that plane.
+message NormalizedVertex {
+  // Required. Horizontal coordinate.
+  float x = 1;
+
+  // Required. Vertical coordinate.
+  float y = 2;
+}
+
+// A bounding polygon of a detected object on a plane.
+// On output both vertices and normalized_vertices are provided.
+// The polygon is formed by connecting vertices in the order they are listed.
+message BoundingPoly {
+  // Output only . The bounding polygon normalized vertices.
+  repeated NormalizedVertex normalized_vertices = 2;
+}

--- a/protos/google/cloud/automl/v1beta1/image.proto
+++ b/protos/google/cloud/automl/v1beta1/image.proto
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
 syntax = "proto3";
 
@@ -26,31 +27,105 @@ option java_outer_classname = "ImageProto";
 option java_package = "com.google.cloud.automl.v1beta1";
 option php_namespace = "Google\\Cloud\\AutoMl\\V1beta1";
 
+
 // Dataset metadata that is specific to image classification.
 message ImageClassificationDatasetMetadata {
-  // Required.
-  // Type of the classification problem.
+  // Required. Type of the classification problem.
   ClassificationType classification_type = 1;
+}
+
+// Dataset metadata specific to image object detection.
+message ImageObjectDetectionDatasetMetadata {
+
 }
 
 // Model metadata for image classification.
 message ImageClassificationModelMetadata {
   // Optional. The ID of the `base` model. If it is specified, the new model
   // will be created based on the `base` model. Otherwise, the new model will be
-  // created from scratch. The `base` model is expected to be in the same
-  // `project` and `location` as the new model to create.
+  // created from scratch. The `base` model must be in the same
+  // `project` and `location` as the new model to create, and have the same
+  // `model_type`.
   string base_model_id = 1;
 
-  // Required. The train budget of creating this model. The actual
-  // `train_cost` will be equal or less than this value.
+  // Required. The train budget of creating this model, expressed in hours. The
+  // actual `train_cost` will be equal or less than this value.
   int64 train_budget = 2;
 
-  // Output only. The actual train cost of creating this model. If this
-  // model is created from a `base` model, the train cost used to create the
-  // `base` model are not included.
+  // Output only. The actual train cost of creating this model, expressed in
+  // hours. If this model is created from a `base` model, the train cost used
+  // to create the `base` model are not included.
   int64 train_cost = 3;
 
   // Output only. The reason that this create model operation stopped,
-  // e.g. BUDGET_REACHED, CONVERGED.
+  // e.g. `BUDGET_REACHED`, `MODEL_CONVERGED`.
   string stop_reason = 5;
+
+  // Optional. Type of the model. The available values are:
+  // *   `cloud` - Model to be used via prediction calls to AutoML API.
+  //               This is the default value.
+  // *   `mobile-low-latency-1` - A model that, in addition to providing
+  //               prediction via AutoML API, can also be exported (see
+  //               [AutoMl.ExportModel][google.cloud.automl.v1beta1.AutoMl.ExportModel]) and used on a mobile or edge device
+  //               with TensorFlow afterwards. Expected to have low latency, but
+  //               may have lower prediction quality than other models.
+  // *   `mobile-versatile-1` - A model that, in addition to providing
+  //               prediction via AutoML API, can also be exported (see
+  //               [AutoMl.ExportModel][google.cloud.automl.v1beta1.AutoMl.ExportModel]) and used on a mobile or edge device
+  //               with TensorFlow afterwards.
+  // *   `mobile-high-accuracy-1` - A model that, in addition to providing
+  //               prediction via AutoML API, can also be exported (see
+  //               [AutoMl.ExportModel][google.cloud.automl.v1beta1.AutoMl.ExportModel]) and used on a mobile or edge device
+  //               with TensorFlow afterwards.  Expected to have a higher
+  //               latency, but should also have a higher prediction quality
+  //               than other models.
+  // *   `mobile-core-ml-low-latency-1` - A model that, in addition to providing
+  //               prediction via AutoML API, can also be exported (see
+  //               [AutoMl.ExportModel][google.cloud.automl.v1beta1.AutoMl.ExportModel]) and used on a mobile device with Core
+  //               ML afterwards. Expected to have low latency, but may have
+  //               lower prediction quality than other models.
+  // *   `mobile-core-ml-versatile-1` - A model that, in addition to providing
+  //               prediction via AutoML API, can also be exported (see
+  //               [AutoMl.ExportModel][google.cloud.automl.v1beta1.AutoMl.ExportModel]) and used on a mobile device with Core
+  //               ML afterwards.
+  // *   `mobile-core-ml-high-accuracy-1` - A model that, in addition to
+  //               providing prediction via AutoML API, can also be exported
+  //               (see [AutoMl.ExportModel][google.cloud.automl.v1beta1.AutoMl.ExportModel]) and used on a mobile device with
+  //               Core ML afterwards.  Expected to have a higher latency, but
+  //               should also have a higher prediction quality than other
+  //               models.
+  string model_type = 7;
+}
+
+// Model metadata specific to image object detection.
+message ImageObjectDetectionModelMetadata {
+  // Optional. Type of the model. The available values are:
+  // *   `cloud-high-accuracy-1` - (default) A model to be used via prediction
+  //               calls to AutoML API. Expected to have a higher latency, but
+  //               should also have a higher prediction quality than other
+  //               models.
+  // *   `cloud-low-latency-1` -  A model to be used via prediction
+  //               calls to AutoML API. Expected to have low latency, but may
+  //               have lower prediction quality than other models.
+  string model_type = 1;
+
+  // Output only. The number of nodes this model is deployed on. A node is an
+  // abstraction of a machine resource, which can handle online prediction QPS
+  // as given in the qps_per_node field.
+  int64 node_count = 3;
+
+  // Output only. An approximate number of online prediction QPS that can
+  // be supported by this model per each node on which it is deployed.
+  double node_qps = 4;
+}
+
+// Model deployment metadata specific to Image Object Detection.
+message ImageObjectDetectionModelDeploymentMetadata {
+  // Input only. The number of nodes to deploy the model on. A node is an
+  // abstraction of a machine resource, which can handle online prediction QPS
+  // as given in the model's
+  //
+  // [qps_per_node][google.cloud.automl.v1beta1.ImageObjectDetectionModelMetadata.qps_per_node].
+  // Must be between 1 and 100, inclusive on both ends.
+  int64 node_count = 1;
 }

--- a/protos/google/cloud/automl/v1beta1/io.proto
+++ b/protos/google/cloud/automl/v1beta1/io.proto
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
 syntax = "proto3";
 
@@ -23,33 +24,762 @@ option java_multiple_files = true;
 option java_package = "com.google.cloud.automl.v1beta1";
 option php_namespace = "Google\\Cloud\\AutoMl\\V1beta1";
 
-// Input configuration.
+
+// Input configuration for ImportData Action.
+//
+// The format of input depends on dataset_metadata the Dataset into which
+// the import is happening has. As input source the
+// [gcs_source][google.cloud.automl.v1beta1.InputConfig.gcs_source]
+// is expected, unless specified otherwise. If a file with identical content
+// (even if it had different GCS_FILE_PATH) is mentioned multiple times , then
+// its label, bounding boxes etc. are appended. The same file should be always
+// provided with the same ML_USE and GCS_FILE_PATH, if it is not then
+// these values are nondeterministically selected from the given ones.
+//
+// The formats are represented in EBNF with commas being literal and with
+// non-terminal symbols defined near the end of this comment. The formats are:
+//
+//  *  For Image Object Detection:
+//         CSV file(s) with each line in format:
+//           ML_USE,GCS_FILE_PATH,LABEL,BOUNDING_BOX
+//           GCS_FILE_PATH leads to image of up to 30MB in size. Supported
+//           extensions: .JPEG, .GIF, .PNG.
+//           Each image is assumed to be exhaustively labeled. The
+//           minimum allowed BOUNDING_BOX edge length is 0.01, and no more than
+//           500 BOUNDING_BOX-es per image are allowed.
+//         Three sample rows:
+//           TRAIN,gs://folder/image1.png,car,0.1,0.1,,,0.3,0.3,,
+//           TRAIN,gs://folder/image1.png,bike,.7,.6,,,.8,.9,,
+//           TEST,gs://folder/im2.png,car,0.1,0.1,0.2,0.1,0.2,0.3,0.1,0.3
+//
+//
+//  *  For Video Classification:
+//         CSV file(s) with each line in format:
+//           ML_USE,GCS_FILE_PATH
+//           where ML_USE VALIDATE value should not be used. The GCS_FILE_PATH
+//           should lead to another .csv file which describes examples that have
+//           given ML_USE, using the following row format:
+//           GCS_FILE_PATH,LABEL,TIME_SEGMENT_START,TIME_SEGMENT_END
+//           Here GCS_FILE_PATH leads to a video of up to 50GB in size and up
+//           to 3h duration. Supported extensions: .MOV, .MPEG4, .MP4, .AVI.
+//           TIME_SEGMENT_START and TIME_SEGMENT_END must be within the
+//           length of the video, and end has to be after the start. Any segment
+//           of a video which has one or more labels on it, is considered a
+//           hard negative for all other labels. Any segment with no labels on
+//           it is considered to be unknown.
+//         Sample top level CSV file:
+//           TRAIN,gs://folder/train_videos.csv
+//           TEST,gs://folder/test_videos.csv
+//           UNASSIGNED,gs://folder/other_videos.csv
+//         Three sample rows of a CSV file for a particular ML_USE:
+//           gs://folder/video1.avi,car,120,180.000021
+//           gs://folder/video1.avi,bike,150,180.000021
+//           gs://folder/vid2.avi,car,0,60.5
+//  *  For Text Extraction:
+//         CSV file(s) with each line in format:
+//           ML_USE,GCS_FILE_PATH
+//           GCS_FILE_PATH leads to a .JSONL (i.e. JSON Lines) file which either
+//           imports text in-line or as documents.
+//           The in-line .JSONL file contains, per line, a proto that wraps a
+//             TextSnippet proto (in json representation) followed by one or
+//             more AnnotationPayload protos (called annotations), which have
+//             display_name and text_extraction detail populated.
+//             Given text is expected to be annotated exhaustively, e.g. if you
+//             look for animals and text contains "dolphin" that is not labeled,
+//             then "dolphin" will be assumed to not be an animal.
+//             Any given text snippet content must have 30,000 characters or
+//             less, and also be UTF-8 NFC encoded (ASCII already is).
+//           The document .JSONL file contains, per line, a proto that wraps a
+//             Document proto with input_config set. Only PDF documents are
+//             supported now, and each document may be up to 2MB large.
+//             Currently annotations on documents cannot be specified at import.
+//           Any given .JSONL file must be 100MB or smaller.
+//         Three sample CSV rows:
+//           TRAIN,gs://folder/file1.jsonl
+//           VALIDATE,gs://folder/file2.jsonl
+//           TEST,gs://folder/file3.jsonl
+//         Sample in-line JSON Lines file (presented here with artificial line
+//         breaks, but the only actual line break is denoted by \n).:
+//           {
+//             "text_snippet": {
+//               "content": "dog car cat"
+//             },
+//             "annotations": [
+//                {
+//                  "display_name": "animal",
+//                  "text_extraction": {
+//                    "text_segment": {"start_offset": 0, "end_offset": 2}
+//                  }
+//                },
+//                {
+//                  "display_name": "vehicle",
+//                  "text_extraction": {
+//                    "text_segment": {"start_offset": 4, "end_offset": 6}
+//                  }
+//                },
+//                {
+//                  "display_name": "animal",
+//                  "text_extraction": {
+//                    "text_segment": {"start_offset": 8, "end_offset": 10}
+//                  }
+//                }
+//             ]
+//           }\n
+//           {
+//              "text_snippet": {
+//                "content": "This dog is good."
+//              },
+//              "annotations": [
+//                 {
+//                   "display_name": "animal",
+//                   "text_extraction": {
+//                     "text_segment": {"start_offset": 5, "end_offset": 7}
+//                   }
+//                 }
+//              ]
+//           }
+//         Sample document JSON Lines file (presented here with artificial line
+//         breaks, but the only actual line break is denoted by \n).:
+//           {
+//             "document": {
+//               "input_config": {
+//                 "gcs_source": { "input_uris": [ "gs://folder/document1.pdf" ]
+//                 }
+//               }
+//             }
+//           }\n
+//           {
+//             "document": {
+//               "input_config": {
+//                 "gcs_source": { "input_uris": [ "gs://folder/document2.pdf" ]
+//                 }
+//               }
+//             }
+//           }
+//   *  For Tables:
+//         Either
+//         [gcs_source][google.cloud.automl.v1beta1.InputConfig.gcs_source] or
+//
+// [bigquery_source][google.cloud.automl.v1beta1.InputConfig.bigquery_source]
+//         can be used. All inputs will be concatenated into a single
+//
+// [primary_table][google.cloud.automl.v1beta1.TablesDatasetMetadata.primary_table_name]
+//         For gcs_source:
+//           CSV file(s), where first file must have a header containing unique
+//           column names, other files may have such header line too, and all
+//           other lines contain values for the header columns. Each line must
+//           have 1,000,000 or fewer characters.
+//           First three sample rows of a CSV file:
+//           "Id","First Name","Last Name","Dob","Addresses"
+//
+// "1","John","Doe","1968-01-22","[{"status":"current","address":"123_First_Avenue","city":"Seattle","state":"WA","zip":"11111","numberOfYears":"1"},{"status":"previous","address":"456_Main_Street","city":"Portland","state":"OR","zip":"22222","numberOfYears":"5"}]"
+//
+// "2","Jane","Doe","1980-10-16","[{"status":"current","address":"789_Any_Avenue","city":"Albany","state":"NY","zip":"33333","numberOfYears":"2"},{"status":"previous","address":"321_Main_Street","city":"Hoboken","state":"NJ","zip":"44444","numberOfYears":"3"}]}
+//         For bigquery_source:
+//           An URI of a BigQuery table.
+//         An imported table must have between 2 and 1,000 columns, inclusive,
+//         and between 1,000 and 10,000,000 rows, inclusive.
+//
+//  *  For Text Sentiment:
+//         CSV file(s) with each line in format:
+//           ML_USE,TEXT_SNIPPET,SENTIMENT
+//           TEXT_SNIPPET must have up to 500 characters.
+//         Three sample rows:
+//         TRAIN,"@freewrytin God is way too good for Claritin",2
+//         TRAIN,"I need Claritin so bad",3
+//         TEST,"Thank god for Claritin.",4
+//
+//  Definitions:
+//  ML_USE = "TRAIN" | "VALIDATE" | "TEST" | "UNASSIGNED"
+//           Describes how the given example (file) should be used for model
+//           training. "UNASSIGNED" can be used when user has no preference.
+//  GCS_FILE_PATH = A path to file on GCS, e.g. "gs://folder/image1.png".
+//  LABEL = A display name of an object on an image, video etc., e.g. "dog".
+//          Must be up to 32 characters long and can consist only of ASCII
+//          Latin letters A-Z and a-z, underscores(_), and ASCII digits 0-9.
+//          For each label an AnnotationSpec is created which display_name
+//          becomes the label; AnnotationSpecs are given back in predictions.
+//  INSTANCE_ID = A positive integer that identifies a specific instance of a
+//                labeled entity on an example. Used e.g. to track two cars on
+//                a video while being able to tell apart which one is which.
+//  BOUNDING_BOX = VERTEX,VERTEX,VERTEX,VERTEX | VERTEX,,,VERTEX,,
+//                 A rectangle parallel to the frame of the example (image,
+//                 video). If 4 vertices are given they are connected by edges
+//                 in the order provided, if 2 are given they are recognized
+//                 as diagonally opposite vertices of the rectangle.
+//  VERTEX = COORDINATE,COORDINATE
+//           First coordinate is horizontal (x), the second is vertical (y).
+//  COORDINATE = A float in 0 to 1 range, relative to total length of
+//               image or video in given dimension. For fractions the
+//               leading non-decimal 0 can be omitted (i.e. 0.3 = .3).
+//               Point 0,0 is in top left.
+//  TIME_SEGMENT_START = TIME_OFFSET
+//                       Expresses a beginning, inclusive, of a time segment
+//                       within an example that has a time dimension
+//                       (e.g. video).
+//  TIME_SEGMENT_END = TIME_OFFSET
+//                     Expresses an end, exclusive, of a time segment within
+//                     an example that has a time dimension (e.g. video).
+//  TIME_OFFSET = A number of seconds as measured from the start of an
+//                example (e.g. video). Fractions are allowed, up to a
+//                microsecond precision. "inf" is allowed, and it means the end
+//                of the example.
+//  TEXT_SNIPPET = A content of a text snippet, UTF-8 encoded.
+//  SENTIMENT = An integer between 0 and
+//              Dataset.text_sentiment_dataset_metadata.sentiment_max
+//              (inclusive). Describes the ordinal of the sentiment - higher
+//              value means a more positive sentiment. All the values are
+//              completely relative, i.e. neither 0 needs to mean a negative or
+//              neutral sentiment nor sentiment_max needs to mean a positive one
+//              - it is just required that 0 is the least positive sentiment
+//              in the data, and sentiment_max is the  most positive one.
+//              The SENTIMENT shouldn't be confused with "score" or "magnitude"
+//              from the previous Natural Language Sentiment Analysis API.
+//              All SENTIMENT values between 0 and sentiment_max must be
+//              represented in the imported data. On prediction the same 0 to
+//              sentiment_max range will be used. The difference between
+//              neighboring sentiment values needs not to be uniform, e.g. 1 and
+//              2 may be similar whereas the difference between 2 and 3 may be
+//              huge.
+//
+//  Errors:
+//  If any of the provided CSV files can't be parsed or if more than certain
+//  percent of CSV rows cannot be processed then the operation fails and
+//  nothing is imported. Regardless of overall success or failure the per-row
+//  failures, up to a certain count cap, will be listed in
+//  Operation.metadata.partial_failures.
+//
 message InputConfig {
   // Required. The source of the input.
   oneof source {
-    // The GCS location for the input content.
+    // The Google Cloud Storage location for the input content.
     GcsSource gcs_source = 1;
+
+    // The BigQuery location for the input content.
+    BigQuerySource bigquery_source = 3;
+  }
+
+  // Additional domain-specific parameters describing the semantic of the
+  // imported data, any string must be up to 25000
+  // characters long.
+  //
+  // *  For Tables:
+  //    `schema_inference_version` - (integer) Required. The version of the
+  //        algorithm that should be used for the initial inference of the
+  //        schema (columns' DataTypes) of the table the data is being imported
+  //        into. Allowed values: "1".
+  map<string, string> params = 2;
+}
+
+// Input configuration for BatchPredict Action.
+//
+// The format of input depends on the ML problem of the model used for
+// prediction. As input source the
+// [gcs_source][google.cloud.automl.v1beta1.InputConfig.gcs_source]
+// is expected, unless specified otherwise.
+//
+// The formats are represented in EBNF with commas being literal and with
+// non-terminal symbols defined near the end of this comment. The formats are:
+//
+//  *  For Video Classification:
+//         CSV file(s) with each line in format:
+//           GCS_FILE_PATH,TIME_SEGMENT_START,TIME_SEGMENT_END
+//           GCS_FILE_PATH leads to video of up to 50GB in size and up to 3h
+//           duration. Supported extensions: .MOV, .MPEG4, .MP4, .AVI.
+//           TIME_SEGMENT_START and TIME_SEGMENT_END must be within the
+//           length of the video, and end has to be after the start.
+//         Three sample rows:
+//           gs://folder/video1.mp4,10,40
+//           gs://folder/video1.mp4,20,60
+//           gs://folder/vid2.mov,0,inf
+//
+//  * For Text Extraction
+//         .JSONL (i.e. JSON Lines) file(s) which either provide text in-line or
+//         as documents (for a single BatchPredict call only one of the these
+//         formats may be used).
+//         The in-line .JSONL file(s) contain per line a proto that
+//           wraps a temporary user-assigned TextSnippet ID (string up to 2000
+//           characters long) called "id" followed by a TextSnippet proto (in
+//           json representation). Any given text snippet content must have
+//           30,000 characters or less, and also be UTF-8 NFC encoded (ASCII
+//           already is). The IDs provided should be unique.
+//         The document .JSONL file(s) contain, per line, a proto that wraps a
+//           Document proto with input_config set. Only PDF documents are
+//           supported now, and each document must be up to 2MB large.
+//         Any given .JSONL file must be 100MB or smaller, and no more than 20
+//         files may be given.
+//         Sample in-line JSON Lines file (presented here with artificial line
+//         breaks, but the only actual line break is denoted by \n):
+//           {
+//             "id": "my_first_id",
+//             "text_snippet": { "content": "dog car cat"}
+//           }\n
+//           {
+//             "id": "2",
+//             "text_snippet": {
+//               "content": "An elaborate content",
+//               "mime_type": "text/plain"
+//             }
+//           }
+//         Sample document JSON Lines file (presented here with artificial line
+//         breaks, but the only actual line break is denoted by \n).:
+//           {
+//             "document": {
+//               "input_config": {
+//                 "gcs_source": { "input_uris": [ "gs://folder/document1.pdf" ]
+//                 }
+//               }
+//             }
+//           }\n
+//           {
+//             "document": {
+//               "input_config": {
+//                 "gcs_source": { "input_uris": [ "gs://folder/document2.pdf" ]
+//                 }
+//               }
+//             }
+//           }
+//
+//  *  For Tables:
+//         Either
+//         [gcs_source][google.cloud.automl.v1beta1.InputConfig.gcs_source] or
+//
+// [bigquery_source][google.cloud.automl.v1beta1.InputConfig.bigquery_source].
+//         For gcs_source:
+//           CSV file(s), where first file must have a header containing
+//           column names, other files may have such header line too, and all
+//           other lines contain values for the header columns. The column
+//           names must be exactly same (order may differ) as the model's
+//
+// [input_feature_column_specs'][google.cloud.automl.v1beta1.TablesModelMetadata.input_feature_column_specs]
+//           [display_names][google.cloud.automl.v1beta1.display_name], with
+//           values compatible with these column specs data types.
+//           Prediction on all the rows, i.e. the CSV lines, will be
+//           attempted.
+//           Each line must have 1,000,000 or fewer characters.
+//           First three sample rows of a CSV file:
+//           "First Name","Last Name","Dob","Addresses"
+//
+// "John","Doe","1968-01-22","[{"status":"current","address":"123_First_Avenue","city":"Seattle","state":"WA","zip":"11111","numberOfYears":"1"},{"status":"previous","address":"456_Main_Street","city":"Portland","state":"OR","zip":"22222","numberOfYears":"5"}]"
+//
+// "Jane","Doe","1980-10-16","[{"status":"current","address":"789_Any_Avenue","city":"Albany","state":"NY","zip":"33333","numberOfYears":"2"},{"status":"previous","address":"321_Main_Street","city":"Hoboken","state":"NJ","zip":"44444","numberOfYears":"3"}]}
+//         For bigquery_source:
+//           An URI of a BigQuery table. The table's columns must be exactly
+//           same (order may differ) as all model's
+//
+// [input_feature_column_specs'][google.cloud.automl.v1beta1.TablesModelMetadata.input_feature_column_specs]
+//           [display_names][google.cloud.automl.v1beta1.display_name], with
+//           data compatible with these colum specs data types.
+//           Prediction on all the rows of the table will be attempted.
+//
+//  Definitions:
+//  GCS_FILE_PATH = A path to file on GCS, e.g. "gs://folder/video.avi".
+//  TIME_SEGMENT_START = TIME_OFFSET
+//                       Expresses a beginning, inclusive, of a time segment
+//                       within an
+//                       example that has a time dimension (e.g. video).
+//  TIME_SEGMENT_END = TIME_OFFSET
+//                     Expresses an end, exclusive, of a time segment within
+//                     an example that has a time dimension (e.g. video).
+//  TIME_OFFSET = A number of seconds as measured from the start of an
+//                example (e.g. video). Fractions are allowed, up to a
+//                microsecond precision. "inf" is allowed and it means the end
+//                of the example.
+//
+//  Errors:
+//  If any of the provided CSV files can't be parsed or if more than certain
+//  percent of CSV rows cannot be processed then the operation fails and
+//  prediction does not happen. Regardless of overall success or failure the
+//  per-row failures, up to a certain count cap, will be listed in
+//  Operation.metadata.partial_failures.
+//
+message BatchPredictInputConfig {
+  // Required. The source of the input.
+  oneof source {
+    // The Google Cloud Storage location for the input content.
+    GcsSource gcs_source = 1;
+
+    // The BigQuery location for the input content.
+    BigQuerySource bigquery_source = 2;
   }
 }
 
-// Output configuration.
+// Input configuration of a [Document][google.cloud.automl.v1beta1.Document].
+message DocumentInputConfig {
+  // The Google Cloud Storage location of the document file. Only a single path
+  // should be given.
+  // Max supported size: 512MB.
+  // Supported extensions: .PDF.
+  GcsSource gcs_source = 1;
+}
+
+// Output configuration for ExportData.
+//
+// As destination the
+// [gcs_destination][google.cloud.automl.v1beta1.OutputConfig.gcs_destination]
+// must be set unless specified otherwise for a domain.
+// Only ground truth annotations are exported (not approved annotations are
+// not exported).
+//
+// The outputs correspond to how the data was imported, and may be used as
+// input to import data. The output formats are represented as EBNF with literal
+// commas and same non-terminal symbols definitions are these in import data's
+// [InputConfig][google.cloud.automl.v1beta1.InputConfig]:
+//
+//  *  For Image Object Detection:
+//         CSV file(s) `image_object_detection_1.csv`,
+//         `image_object_detection_2.csv`,...,`image_object_detection_N.csv`
+//         with each line in format:
+//         ML_USE,GCS_FILE_PATH,LABEL,BOUNDING_BOX
+//         where GCS_FILE_PATHs point at the original, source locations of the
+//         imported images.
+//
+//  *  For Video Classification:
+//         CSV file `video_classification.csv`, with each line in format:
+//         ML_USE,GCS_FILE_PATH
+//         (may have muliple lines per a single ML_USE).
+//         Each GCS_FILE_PATH leads to another .csv file which
+//         describes examples that have given ML_USE, using the following
+//         row format:
+//         GCS_FILE_PATH,LABEL,TIME_SEGMENT_START,TIME_SEGMENT_END
+//         Here GCS_FILE_PATHs point at the original, source locations of the
+//         imported videos.
+//  *  For Text Extraction:
+//         CSV file `text_extraction.csv`, with each line in format:
+//         ML_USE,GCS_FILE_PATH
+//         GCS_FILE_PATH leads to a .JSONL (i.e. JSON Lines) file which
+//         contains, per line, a proto that wraps a TextSnippet proto (in json
+//         representation) followed by AnnotationPayload protos (called
+//         annotations). If initially documents had been imported, corresponding
+//         OCR-ed representation is returned.
+//
+//   *  For Tables:
+//         Output depends on whether the dataset was imported from GCS or
+//         BigQuery.
+//         GCS case:
+//
+// [gcs_destination][google.cloud.automl.v1beta1.OutputConfig.gcs_destination]
+//           must be set. Exported are CSV file(s) `tables_1.csv`,
+//           `tables_2.csv`,...,`tables_N.csv` with each having as header line
+//           the table's column names, and all other lines contain values for
+//           the header columns.
+//         BigQuery case:
+//
+// [bigquery_destination][google.cloud.automl.v1beta1.OutputConfig.bigquery_destination]
+//           pointing to a BigQuery project must be set. In the given project a
+//           new dataset will be created with name
+//
+// `export_data_<automl-dataset-display-name>_<timestamp-of-export-call>`
+//           where <automl-dataset-display-name> will be made
+//           BigQuery-dataset-name compatible (e.g. most special characters will
+//           become underscores), and timestamp will be in
+//           YYYY_MM_DDThh_mm_ss_sssZ "based on ISO-8601" format. In that
+//           dataset a new table called `primary_table` will be created, and
+//           filled with precisely the same data as this obtained on import.
 message OutputConfig {
   // Required. The destination of the output.
   oneof destination {
-    // The GCS location where the output must be written to.
+    // The Google Cloud Storage location where the output is to be written to.
+    // For Image Object Detection, Text Extraction, Video Classification and
+    // Tables, in the given directory a new directory will be created with name:
+    // export_data-<dataset-display-name>-<timestamp-of-export-call>
+    // where timestamp is in YYYY-MM-DDThh:mm:ss.sssZ ISO-8601 format. All
+    // export output will be written into that directory.
     GcsDestination gcs_destination = 1;
+
+    // The BigQuery location where the output is to be written to.
+    BigQueryDestination bigquery_destination = 2;
   }
 }
 
-// The GCS location for the input content.
+// Output configuration for BatchPredict Action.
+//
+// As destination the
+//
+// [gcs_destination][google.cloud.automl.v1beta1.BatchPredictOutputConfig.gcs_destination]
+// must be set unless specified otherwise for a domain. If gcs_destination is
+// set then in the given directory a new directory will be created. Its name
+// will be
+// "prediction-<model-display-name>-<timestamp-of-prediction-call>",
+// where timestamp is in YYYY-MM-DDThh:mm:ss.sssZ ISO-8601 format. The contents
+// of it depend on the ML problem the predictions are made for.
+//
+//  *  For Video Classification:
+//         In the created directory a video_classification.csv file, and a .JSON
+//         file per each video classification requested in the input (i.e. each
+//         line in given CSV(s)), will be created.
+//
+//         The format of video_classification.csv is:
+//
+// GCS_FILE_PATH,TIME_SEGMENT_START,TIME_SEGMENT_END,JSON_FILE_NAME,STATUS
+//         where:
+//         GCS_FILE_PATH,TIME_SEGMENT_START,TIME_SEGMENT_END = matches 1 to 1
+//             the prediction input lines (i.e. video_classification.csv has
+//             precisely the same number of lines as the prediction input had.)
+//         JSON_FILE_NAME = Name of .JSON file in the output directory, which
+//             contains prediction responses for the video time segment.
+//         STATUS = "OK" if prediction completed successfully, or an error
+//             code and,or message otherwise. If STATUS is not "OK" then the
+//             .JSON file for that line may not exist or be empty.
+//
+//         Each .JSON file, assuming STATUS is "OK", will contain a list of
+//         AnnotationPayload protos in JSON format, which are the predictions
+//         for the video time segment the file is assigned to in the
+//         video_classification.csv. All AnnotationPayload protos will have
+//         video_classification field set, and will be sorted by
+//         video_classification.type field (note that the returned types are
+//         governed by `classifaction_types` parameter in
+//         [PredictService.BatchPredictRequest.params][]).
+//   *  For Text Extraction:
+//         In the created directory files `text_extraction_1.jsonl`,
+//         `text_extraction_2.jsonl`,...,`text_extraction_N.jsonl`
+//         will be created, where N may be 1, and depends on the
+//         total number of inputs and annotations found.
+//         The contents of these .JSONL file(s) depend on whether the input
+//         used inline text, or documents.
+//         If input was inline, then each .JSONL file will contain, per line,
+//           a JSON representation of a proto that wraps given in request text
+//           snippet's "id" : "<id_value>" followed by a list of zero or more
+//           AnnotationPayload protos (called annotations), which have
+//           text_extraction detail populated. A single text snippet will be
+//           listed only once with all its annotations, and its annotations will
+//           never be split across files.
+//         If input used documents, then each .JSONL file will contain, per
+//           line, a JSON representation of a proto that wraps given in request
+//           document proto, followed by its OCR-ed representation in the form
+//           of a text snippet, finally followed by a list of zero or more
+//           AnnotationPayload protos (called annotations), which have
+//           text_extraction detail populated and refer, via their indices, to
+//           the OCR-ed text snippet. A single document (and its text snippet)
+//           will be listed only once with all its annotations, and its
+//           annotations will never be split across files.
+//         If prediction for any text snippet failed (partially or completely),
+//         then additional `errors_1.jsonl`, `errors_2.jsonl`,...,
+//         `errors_N.jsonl` files will be created (N depends on total number of
+//         failed predictions). These files will have a JSON representation of a
+//         proto that wraps either the "id" : "<id_value>" (in case of inline)
+//         or the document proto (in case of document) but here followed by
+//         exactly one
+//
+// [`google.rpc.Status`](https:
+// //github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
+//         containing only `code` and `message`.
+//
+//  *  For Tables:
+//         Output depends on whether
+//
+// [gcs_destination][google.cloud.automl.v1beta1.BatchPredictOutputConfig.gcs_destination]
+//         or
+//
+// [bigquery_destination][google.cloud.automl.v1beta1.BatchPredictOutputConfig.bigquery_destination]
+//         is set (either is allowed).
+//         GCS case:
+//           In the created directory files `tables_1.csv`, `tables_2.csv`,...,
+//           `tables_N.csv` will be created, where N may be 1, and depends on
+//           the total number of the successfully predicted rows.
+//           For the classification models:
+//             Each .csv file will contain a header, listing all model's
+//
+// [input_feature_column_specs'][google.cloud.automl.v1beta1.TablesModelMetadata.input_feature_column_specs]
+//
+// [display_names][google.cloud.automl.v1beta1.ColumnSpec.display_name]
+//             followed by M target column names in the format of
+//
+// "<[target_column_specs][google.cloud.automl.v1beta1.TablesModelMetadata.target_column_spec]
+//
+// [display_name][google.cloud.automl.v1beta1.ColumnSpec.display_name]>_<target
+//             value>_score" where M is the number of distinct target values,
+//             i.e. number of distinct values in the target column of the table
+//             used to train the model. Subsequent lines will contain the
+//             respective values of successfully predicted rows, with the last,
+//             i.e. the target, columns having the corresponding prediction
+//             [scores][google.cloud.automl.v1beta1.TablesAnnotation.score].
+//           For the regression models:
+//             Each .csv file will contain a header, listing all model's
+//
+// [input_feature_column_specs][google.cloud.automl.v1beta1.TablesModelMetadata.input_feature_column_specs]
+//             [display_names][google.cloud.automl.v1beta1.display_name]
+//             followed by the target column with name equal to
+//
+// [target_column_specs'][google.cloud.automl.v1beta1.TablesModelMetadata.target_column_spec]
+//
+// [display_name][google.cloud.automl.v1beta1.ColumnSpec.display_name].
+//             Subsequent lines will contain the respective values of
+//             successfully predicted rows, with the last, i.e. the target,
+//             column having the predicted target value.
+//           If prediction for any rows failed, then an additional
+//           `errors_1.csv`, `errors_2.csv`,..., `errors_N.csv` will be created
+//           (N depends on total number of failed rows). These files will have
+//           analogous format as `tables_*.csv`, but always with a single target
+//           column having
+//
+// [`google.rpc.Status`](https:
+// //github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
+//           represented as a JSON string, and containing only `code` and
+//           `message`.
+//        BigQuery case:
+//
+// [bigquery_destination][google.cloud.automl.v1beta1.OutputConfig.bigquery_destination]
+//           pointing to a BigQuery project must be set. In the given project a
+//           new dataset will be created with name
+//           `prediction_<model-display-name>_<timestamp-of-prediction-call>`
+//           where <model-display-name> will be made
+//           BigQuery-dataset-name compatible (e.g. most special characters will
+//           become underscores), and timestamp will be in
+//           YYYY_MM_DDThh_mm_ss_sssZ "based on ISO-8601" format. In the dataset
+//           two tables will be created, `predictions`, and `errors`.
+//           The `predictions` table's column names will be the
+//
+// [input_feature_column_specs'][google.cloud.automl.v1beta1.TablesModelMetadata.input_feature_column_specs]
+//
+// [display_names][google.cloud.automl.v1beta1.ColumnSpec.display_name]
+//           followed by model's
+//
+// [target_column_specs'][google.cloud.automl.v1beta1.TablesModelMetadata.target_column_spec]
+//
+// [display_name][google.cloud.automl.v1beta1.ColumnSpec.display_name].
+//           The input feature columns will contain the respective values of
+//           successfully predicted rows, with the target column having an
+//           ARRAY of
+//
+// [AnnotationPayloads][google.cloud.automl.v1beta1.AnnotationPayload],
+//           represented as STRUCT-s, containing
+//           [TablesAnnotation][google.cloud.automl.v1beta1.TablesAnnotation].
+//           The `errors` table contains rows for which the prediction has
+//           failed, it has analogous input feature and target columns, but
+//           here the target column as a value has
+//
+// [`google.rpc.Status`](https:
+// //github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
+//           represented as a STRUCT, and containing only `code` and `message`.
+message BatchPredictOutputConfig {
+  // Required. The destination of the output.
+  oneof destination {
+    // The Google Cloud Storage location of the directory where the output is to
+    // be written to.
+    GcsDestination gcs_destination = 1;
+
+    // The BigQuery location where the output is to be written to.
+    BigQueryDestination bigquery_destination = 2;
+  }
+}
+
+// Output configuration for ModelExport Action.
+message ModelExportOutputConfig {
+  // Required. The destination of the output.
+  oneof destination {
+    // The Google Cloud Storage location where the model is to be written to.
+    // This location may only be set for the following model formats:
+    //   "tflite", "edgetpu_tflite", "core_ml", "docker".
+    //
+    //  Under the directory given as the destination a new one with name
+    //  "model-export-<model-display-name>-<timestamp-of-export-call>",
+    //  where timestamp is in YYYY-MM-DDThh:mm:ss.sssZ ISO-8601 format,
+    //  will be created. Inside the model and any of its supporting files
+    //  will be written, as described
+    //
+    // [here](https:
+    // //cloud.google.com/vision/automl/alpha/d
+    // // ocs/predict#deployment_to_devices).
+    GcsDestination gcs_destination = 1;
+
+    // The GCR location where model image is to be pushed to. This location
+    // may only be set for the following model formats:
+    //   "docker".
+    //
+    // The model image will be created under the given URI.
+    GcrDestination gcr_destination = 3;
+  }
+
+  // The format in which the model must be exported. The available, and default,
+  // formats depend on the problem and model type (if given problem and type
+  // combination doesn't have a format listed, it means its models are not
+  // exportable):
+  //
+  // *  For Image Classification mobile-low-latency-1, mobile-versatile-1,
+  //        mobile-high-accuracy-1:
+  //      "tflite" (default), "edgetpu_tflite", "tf_saved_model", "docker".
+  //
+  // *  For Image Classification mobile-core-ml-low-latency-1,
+  //        mobile-core-ml-versatile-1, mobile-core-ml-high-accuracy-1:
+  //      "core_ml" (default).
+  // Formats description:
+  //
+  // * tflite - Used for Android mobile devices.
+  // * edgetpu_tflite - Used for [Edge TPU](https://cloud.google.com/edge-tpu/)
+  //                    devices.
+  // * tf_saved_model - A tensorflow model in SavedModel format.
+  // * docker - Used for Docker containers. Use the params field to customize
+  //            the container. The container is verified to work correctly on
+  //            ubuntu 16.04 operating system.
+  // * core_ml - Used for iOS mobile devices.
+  string model_format = 4;
+
+  // Additional model-type and format specific parameters describing the
+  // requirements for the to be exported model files, any string must be up to
+  // 25000 characters long.
+  //
+  //  * For `docker` format:
+  //     `cpu_architecture` - (string) "x86_64" (default).
+  //     `gpu_architecture` - (string) "none" (default), "nvidia".
+  map<string, string> params = 2;
+}
+
+// Output configuration for ExportEvaluatedExamples Action. Note that this call
+// is available only for 30 days since the moment the model was evaluated.
+// The output depends on the domain, as follows (note that only examples from
+// the TEST set are exported):
+//
+//  *  For Tables:
+//
+// [bigquery_destination][google.cloud.automl.v1beta1.OutputConfig.bigquery_destination]
+//       pointing to a BigQuery project must be set. In the given project a
+//       new dataset will be created with name
+//
+// `export_evaluated_examples_<model-display-name>_<timestamp-of-export-call>`
+//       where <model-display-name> will be made BigQuery-dataset-name
+//       compatible (e.g. most special characters will become underscores),
+//       and timestamp will be in YYYY_MM_DDThh_mm_ss_sssZ "based on ISO-8601"
+//       format. In the dataset an `evaluated_examples` table will be
+//       created. It will have all the same columns as the
+//       [primary
+//
+// table][google.cloud.automl.v1beta1.TablesDatasetMetadata.primary_table_spec_id]
+//       of the
+//       [dataset][google.cloud.automl.v1beta1.Model.dataset_id] from which
+//       the model was created, as they were at the moment of model's
+//       evaluation (this includes the target column with its ground
+//       truth), followed by a column called "predicted_<target_column>". That
+//       last column will contain the model's prediction result for each
+//       respective row, given as ARRAY of
+//       [AnnotationPayloads][google.cloud.automl.v1beta1.AnnotationPayload],
+//       represented as STRUCT-s, containing
+//       [TablesAnnotation][google.cloud.automl.v1beta1.TablesAnnotation].
+message ExportEvaluatedExamplesOutputConfig {
+  // Required. The destination of the output.
+  oneof destination {
+    // The BigQuery location where the output is to be written to.
+    BigQueryDestination bigquery_destination = 2;
+  }
+}
+
+// The Google Cloud Storage location for the input content.
 message GcsSource {
   // Required. Google Cloud Storage URIs to input files, up to 2000 characters
   // long. Accepted forms:
-  // * Full object path: gs://bucket/directory/object.csv
+  // * Full object path, e.g. gs://bucket/directory/object.csv
   repeated string input_uris = 1;
 }
 
-// The GCS location where the output must be written to
+// The BigQuery location for the input content.
+message BigQuerySource {
+  // Required. BigQuery URI to a table, up to 2000 characters long.
+  // Accepted forms:
+  // *  BigQuery path e.g. bq://projectId.bqDatasetId.bqTableId
+  string input_uri = 1;
+}
+
+// The Google Cloud Storage location where the output is to be written to.
 message GcsDestination {
   // Required. Google Cloud Storage URI to output directory, up to 2000
   // characters long.
@@ -58,4 +788,28 @@ message GcsDestination {
   // The requesting user must have write permission to the bucket.
   // The directory is created if it doesn't exist.
   string output_uri_prefix = 1;
+}
+
+// The BigQuery location for the output content.
+message BigQueryDestination {
+  // Required. BigQuery URI to a project, up to 2000 characters long.
+  // Accepted forms:
+  // *  BigQuery path e.g. bq://projectId
+  string output_uri = 1;
+}
+
+// The GCR location where the image must be pushed to.
+message GcrDestination {
+  // Required. Google Contained Registry URI of the new image, up to 2000
+  // characters long. See
+  //
+  // https:
+  // //cloud.google.com/container-registry/do
+  // // cs/pushing-and-pulling#pushing_an_image_to_a_registry
+  // Accepted forms:
+  // * [HOSTNAME]/[PROJECT-ID]/[IMAGE]
+  // * [HOSTNAME]/[PROJECT-ID]/[IMAGE]:[TAG]
+  //
+  // The requesting user must have permission to push images the project.
+  string output_uri = 1;
 }

--- a/protos/google/cloud/automl/v1beta1/io.proto
+++ b/protos/google/cloud/automl/v1beta1/io.proto
@@ -676,11 +676,7 @@ message ModelExportOutputConfig {
     //  "model-export-<model-display-name>-<timestamp-of-export-call>",
     //  where timestamp is in YYYY-MM-DDThh:mm:ss.sssZ ISO-8601 format,
     //  will be created. Inside the model and any of its supporting files
-    //  will be written, as described
-    //
-    // [here](https:
-    // //cloud.google.com/vision/automl/alpha/d
-    // // ocs/predict#deployment_to_devices).
+    //  will be written.
     GcsDestination gcs_destination = 1;
 
     // The GCR location where model image is to be pushed to. This location

--- a/protos/google/cloud/automl/v1beta1/model.proto
+++ b/protos/google/cloud/automl/v1beta1/model.proto
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
 syntax = "proto3";
 
@@ -18,14 +19,17 @@ package google.cloud.automl.v1beta1;
 
 import "google/api/annotations.proto";
 import "google/cloud/automl/v1beta1/image.proto";
+import "google/cloud/automl/v1beta1/tables.proto";
 import "google/cloud/automl/v1beta1/text.proto";
 import "google/cloud/automl/v1beta1/translation.proto";
+import "google/cloud/automl/v1beta1/video.proto";
 import "google/protobuf/timestamp.proto";
 
 option go_package = "google.golang.org/genproto/googleapis/cloud/automl/v1beta1;automl";
 option java_multiple_files = true;
 option java_package = "com.google.cloud.automl.v1beta1";
 option php_namespace = "Google\\Cloud\\AutoMl\\V1beta1";
+
 
 // API proto representing a trained machine learning model.
 message Model {
@@ -45,14 +49,29 @@ message Model {
   // The model metadata that is specific to the problem type.
   // Must match the metadata type of the dataset used to train the model.
   oneof model_metadata {
+    // Metadata for translation models.
+    TranslationModelMetadata translation_model_metadata = 15;
+
     // Metadata for image classification models.
     ImageClassificationModelMetadata image_classification_model_metadata = 13;
 
     // Metadata for text classification models.
     TextClassificationModelMetadata text_classification_model_metadata = 14;
 
-    // Metadata for translation models.
-    TranslationModelMetadata translation_model_metadata = 15;
+    // Metadata for image object detection models.
+    ImageObjectDetectionModelMetadata image_object_detection_model_metadata = 20;
+
+    // Metadata for video classification models.
+    VideoClassificationModelMetadata video_classification_model_metadata = 23;
+
+    // Metadata for text extraction models.
+    TextExtractionModelMetadata text_extraction_model_metadata = 19;
+
+    // Metadata for Tables models.
+    TablesModelMetadata tables_model_metadata = 24;
+
+    // Metadata for text sentiment models.
+    TextSentimentModelMetadata text_sentiment_model_metadata = 22;
   }
 
   // Output only.
@@ -61,15 +80,14 @@ message Model {
   string name = 1;
 
   // Required. The name of the model to show in the interface. The name can be
-  // up to 32 characters
-  // long and can consist only of ASCII Latin letters A-Z and a-z, underscores
-  // (_), and ASCII digits 0-9.
+  // up to 32 characters long and can consist only of ASCII Latin letters A-Z
+  // and a-z, underscores
+  // (_), and ASCII digits 0-9. It must start with a letter.
   string display_name = 2;
 
   // Required.
   // The resource ID of the dataset used to create the model. The dataset must
-  // come from the
-  // same ancestor project and location.
+  // come from the same ancestor project and location.
   string dataset_id = 3;
 
   // Output only.
@@ -80,6 +98,7 @@ message Model {
   // Timestamp when this model was last updated.
   google.protobuf.Timestamp update_time = 11;
 
-  // Output only. Deployment state of the model.
+  // Output only. Deployment state of the model. A model can only serve
+  // prediction requests after it gets deployed.
   DeploymentState deployment_state = 8;
 }

--- a/protos/google/cloud/automl/v1beta1/model_evaluation.proto
+++ b/protos/google/cloud/automl/v1beta1/model_evaluation.proto
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
 syntax = "proto3";
 
@@ -18,6 +19,11 @@ package google.cloud.automl.v1beta1;
 
 import "google/api/annotations.proto";
 import "google/cloud/automl/v1beta1/classification.proto";
+import "google/cloud/automl/v1beta1/detection.proto";
+import "google/cloud/automl/v1beta1/regression.proto";
+import "google/cloud/automl/v1beta1/tables.proto";
+import "google/cloud/automl/v1beta1/text_extraction.proto";
+import "google/cloud/automl/v1beta1/text_sentiment.proto";
 import "google/cloud/automl/v1beta1/translation.proto";
 import "google/protobuf/timestamp.proto";
 
@@ -26,15 +32,33 @@ option java_multiple_files = true;
 option java_package = "com.google.cloud.automl.v1beta1";
 option php_namespace = "Google\\Cloud\\AutoMl\\V1beta1";
 
+
 // Evaluation results of a model.
 message ModelEvaluation {
   // Output only. Problem type specific evaluation metrics.
   oneof metrics {
-    // Evaluation metrics for models on classification problems models.
+    // Model evaluation metrics for image, text, video and tables
+    // classification.
+    // Tables problem is considered a classification when the target column
+    // has either CATEGORY or ARRAY(CATEGORY) DataType.
     ClassificationEvaluationMetrics classification_evaluation_metrics = 8;
 
-    // Evaluation metrics for models on translation models.
+    // Model evaluation metrics for Tables regression.
+    // Tables problem is considered a regression when the target column
+    // has FLOAT64 DataType.
+    RegressionEvaluationMetrics regression_evaluation_metrics = 24;
+
+    // Model evaluation metrics for translation.
     TranslationEvaluationMetrics translation_evaluation_metrics = 9;
+
+    // Model evaluation metrics for image object detection.
+    ImageObjectDetectionEvaluationMetrics image_object_detection_evaluation_metrics = 12;
+
+    // Evaluation metrics for text sentiment models.
+    TextSentimentEvaluationMetrics text_sentiment_evaluation_metrics = 11;
+
+    // Evaluation metrics for text extraction models.
+    TextExtractionEvaluationMetrics text_extraction_evaluation_metrics = 13;
   }
 
   // Output only.
@@ -46,16 +70,36 @@ message ModelEvaluation {
 
   // Output only.
   // The ID of the annotation spec that the model evaluation applies to. The
-  // ID is empty for overall model evaluation.
+  // The ID is empty for the overall model evaluation.
+  // For Tables classification these are the distinct values of the target
+  // column at the moment of the evaluation; for this problem annotation specs
+  // in the dataset do not exist.
   // NOTE: Currently there is no way to obtain the display_name of the
   // annotation spec from its ID. To see the display_names, review the model
   // evaluations in the UI.
   string annotation_spec_id = 2;
 
+  // Output only. The value of [AnnotationSpec.display_name][google.cloud.automl.v1beta1.AnnotationSpec.display_name] when the model
+  // was trained. Because this field returns a value at model training time,
+  // for different models trained using the same dataset, the returned value
+  // could be different as model owner could update the display_name between
+  // any two model training.
+  // The display_name is empty for the overall model evaluation.
+  string display_name = 15;
+
   // Output only.
   // Timestamp when this model evaluation was created.
   google.protobuf.Timestamp create_time = 5;
 
-  // Output only. The number of examples used for model evaluation.
+  // Output only.
+  // The number of examples used for model evaluation, i.e. for
+  // which ground truth from time of model creation is compared against the
+  // predicted annotations created by the model.
+  // For overall ModelEvaluation (i.e. with annotation_spec_id not set) this is
+  // the total number of all examples used for evaluation.
+  // Otherwise, this is the count of examples that according to the ground
+  // truth were annotated by the
+  //
+  // [annotation_spec_id][google.cloud.automl.v1beta1.ModelEvaluation.annotation_spec_id].
   int32 evaluated_example_count = 6;
 }

--- a/protos/google/cloud/automl/v1beta1/operations.proto
+++ b/protos/google/cloud/automl/v1beta1/operations.proto
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,12 +11,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
 syntax = "proto3";
 
 package google.cloud.automl.v1beta1;
 
 import "google/api/annotations.proto";
+import "google/cloud/automl/v1beta1/io.proto";
 import "google/cloud/automl/v1beta1/model.proto";
 import "google/cloud/automl/v1beta1/model_evaluation.proto";
 import "google/protobuf/empty.proto";
@@ -28,16 +30,42 @@ option java_multiple_files = true;
 option java_package = "com.google.cloud.automl.v1beta1";
 option php_namespace = "Google\\Cloud\\AutoMl\\V1beta1";
 
+
 // Metadata used across all long running operations returned by AutoML API.
 message OperationMetadata {
   // Ouptut only. Details of specific operation. Even if this field is empty,
   // the presence allows to distinguish different types of operations.
   oneof details {
+    // Details of a Delete operation.
+    DeleteOperationMetadata delete_details = 8;
+
+    // Details of a DeployModel operation.
+    DeployModelOperationMetadata deploy_model_details = 24;
+
+    // Details of an UndeployModel operation.
+    UndeployModelOperationMetadata undeploy_model_details = 25;
+
     // Details of CreateModel operation.
     CreateModelOperationMetadata create_model_details = 10;
+
+    // Details of ImportData operation.
+    ImportDataOperationMetadata import_data_details = 15;
+
+    // Details of BatchPredict operation.
+    BatchPredictOperationMetadata batch_predict_details = 16;
+
+    // Details of ExportData operation.
+    ExportDataOperationMetadata export_data_details = 21;
+
+    // Details of ExportModel operation.
+    ExportModelOperationMetadata export_model_details = 22;
+
+    // Details of ExportEvaluatedExamples operation.
+    ExportEvaluatedExamplesOperationMetadata export_evaluated_examples_details = 26;
   }
 
   // Output only. Progress of operation. Range: [0, 100].
+  // Not used currently.
   int32 progress_percent = 13;
 
   // Output only. Partial failures encountered.
@@ -53,5 +81,110 @@ message OperationMetadata {
   google.protobuf.Timestamp update_time = 4;
 }
 
+// Details of operations that perform deletes of any entities.
+message DeleteOperationMetadata {
+
+}
+
+// Details of DeployModel operation.
+message DeployModelOperationMetadata {
+
+}
+
+// Details of UndeployModel operation.
+message UndeployModelOperationMetadata {
+
+}
+
 // Details of CreateModel operation.
-message CreateModelOperationMetadata {}
+message CreateModelOperationMetadata {
+
+}
+
+// Details of ImportData operation.
+message ImportDataOperationMetadata {
+
+}
+
+// Details of ExportData operation.
+message ExportDataOperationMetadata {
+  // Further describes this export data's output.
+  // Supplements
+  // [OutputConfig][google.cloud.automl.v1beta1.OutputConfig].
+  message ExportDataOutputInfo {
+    // The output location to which the exported data is written.
+    oneof output_location {
+      // The full path of the Google Cloud Storage directory created, into which
+      // the exported data is written.
+      string gcs_output_directory = 1;
+
+      // The path of the BigQuery dataset created, in bq://projectId.bqDatasetId
+      // format, into which the exported data is written.
+      string bigquery_output_dataset = 2;
+    }
+  }
+
+  // Output only. Information further describing this export data's output.
+  ExportDataOutputInfo output_info = 1;
+}
+
+// Details of BatchPredict operation.
+message BatchPredictOperationMetadata {
+  // Further describes this batch predict's output.
+  // Supplements
+  //
+  // [BatchPredictionOutputConfig][google.cloud.automl.v1beta1.BatchPredictionOutputConfig].
+  message BatchPredictOutputInfo {
+    // The output location into which prediction output is written.
+    oneof output_location {
+      // The full path of the Google Cloud Storage directory created, into which
+      // the prediction output is written.
+      string gcs_output_directory = 1;
+
+      // The path of the BigQuery dataset created, in bq://projectId.bqDatasetId
+      // format, into which the prediction output is written.
+      string bigquery_output_dataset = 2;
+    }
+  }
+
+  // Output only. The input config that was given upon starting this
+  // batch predict operation.
+  BatchPredictInputConfig input_config = 1;
+
+  // Output only. Information further describing this batch predict's output.
+  BatchPredictOutputInfo output_info = 2;
+}
+
+// Details of ExportModel operation.
+message ExportModelOperationMetadata {
+  // Further describes the output of model export.
+  // Supplements
+  //
+  // [ModelExportOutputConfig][google.cloud.automl.v1beta1.ModelExportOutputConfig].
+  message ExportModelOutputInfo {
+    // The full path of the Google Cloud Storage directory created, into which
+    // the model will be exported.
+    string gcs_output_directory = 1;
+  }
+
+  // Output only. Information further describing the output of this model
+  // export.
+  ExportModelOutputInfo output_info = 2;
+}
+
+// Details of EvaluatedExamples operation.
+message ExportEvaluatedExamplesOperationMetadata {
+  // Further describes the output of the evaluated examples export.
+  // Supplements
+  //
+  // [ExportEvaluatedExamplesOutputConfig][google.cloud.automl.v1beta1.ExportEvaluatedExamplesOutputConfig].
+  message ExportEvaluatedExamplesOutputInfo {
+    // The path of the BigQuery dataset created, in bq://projectId.bqDatasetId
+    // format, into which the output of export evaluated examples is written.
+    string bigquery_output_dataset = 2;
+  }
+
+  // Output only. Information further describing the output of this evaluated
+  // examples export.
+  ExportEvaluatedExamplesOutputInfo output_info = 2;
+}

--- a/protos/google/cloud/automl/v1beta1/prediction_service.proto
+++ b/protos/google/cloud/automl/v1beta1/prediction_service.proto
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
 syntax = "proto3";
 
@@ -19,6 +20,9 @@ package google.cloud.automl.v1beta1;
 import "google/api/annotations.proto";
 import "google/cloud/automl/v1beta1/annotation_payload.proto";
 import "google/cloud/automl/v1beta1/data_items.proto";
+import "google/cloud/automl/v1beta1/io.proto";
+import "google/cloud/automl/v1beta1/operations.proto";
+import "google/longrunning/operations.proto";
 
 option go_package = "google.golang.org/genproto/googleapis/cloud/automl/v1beta1;automl";
 option java_multiple_files = true;
@@ -26,19 +30,53 @@ option java_outer_classname = "PredictionServiceProto";
 option java_package = "com.google.cloud.automl.v1beta1";
 option php_namespace = "Google\\Cloud\\AutoMl\\V1beta1";
 
+
 // AutoML Prediction API.
+//
+// On any input that is documented to expect a string parameter in
+// snake_case or kebab-case, either of those cases is accepted.
 service PredictionService {
-  // Perform a prediction.
+  // Perform an online prediction. The prediction result will be directly
+  // returned in the response.
+  // Available for following ML problems, and their expected request payloads:
+  // * Image Classification - Image in .JPEG, .GIF or .PNG format, image_bytes
+  //                          up to 30MB.
+  // * Image Object Detection - Image in .JPEG, .GIF or .PNG format, image_bytes
+  //                            up to 30MB.
+  // * Text Classification - TextSnippet, content up to 10,000 characters,
+  //                         UTF-8 encoded.
+  // * Text Extraction - TextSnippet, content up to 30,000 characters,
+  //                     UTF-8 NFC encoded. * Translation - TextSnippet, content up to 25,000 characters, UTF-8
+  //                 encoded.
+  // * Tables - Row, with column values matching the columns of the model,
+  //            up to 5MB.
+  // * Text Sentiment - TextSnippet, content up 500 characters, UTF-8 encoded.
   rpc Predict(PredictRequest) returns (PredictResponse) {
     option (google.api.http) = {
       post: "/v1beta1/{name=projects/*/locations/*/models/*}:predict"
       body: "*"
     };
   }
+
+  // Perform a batch prediction. Unlike the online [Predict][google.cloud.automl.v1beta1.PredictionService.Predict], batch
+  // prediction result won't be immediately available in the response. Instead,
+  // a long running operation object is returned. User can poll the operation
+  // result via [GetOperation][google.longrunning.Operations.GetOperation]
+  // method. Once the operation is done, [BatchPredictResult][google.cloud.automl.v1beta1.BatchPredictResult] is returned in
+  // the [response][google.longrunning.Operation.response] field.
+  // Available for following ML problems:
+  // * Video Classification
+  // * Text Extraction
+  // * Tables
+  rpc BatchPredict(BatchPredictRequest) returns (google.longrunning.Operation) {
+    option (google.api.http) = {
+      post: "/v1beta1/{name=projects/*/locations/*/models/*}:batchPredict"
+      body: "*"
+    };
+  }
 }
 
-// Request message for
-// [PredictionService.Predict][google.cloud.automl.v1beta1.PredictionService.Predict].
+// Request message for [PredictionService.Predict][google.cloud.automl.v1beta1.PredictionService.Predict].
 message PredictRequest {
   // Name of the model requested to serve the prediction.
   string name = 1;
@@ -54,22 +92,88 @@ message PredictRequest {
   // *  For Image Classification:
   //
   //    `score_threshold` - (float) A value from 0.0 to 1.0. When the model
-  //     makes predictions for an
-  //     image, it will only produce results that have at least this confidence
-  //     score threshold. The default is 0.5.
+  //     makes predictions for an image, it will only produce results that have
+  //     at least this confidence score. The default is 0.5.
+  //
+  //  *  For Image Object Detection:
+  //    `score_threshold` - (float) When Model detects objects on the image,
+  //        it will only produce bounding boxes which have at least this
+  //        confidence score. Value in 0 to 1 range, default is 0.5.
+  //    `max_bounding_box_count` - (int64) No more than this number of bounding
+  //        boxes will be returned in the response. Default is 100, the
+  //        requested value may be limited by server.
   map<string, string> params = 3;
 }
 
-// Response message for
-// [PredictionService.Predict][google.cloud.automl.v1beta1.PredictionService.Predict].
-//
-// Currently, this is only
-// used to return an image recognition prediction result. More prediction
-// output metadata might be introduced in the future.
+// Response message for [PredictionService.Predict][google.cloud.automl.v1beta1.PredictionService.Predict].
 message PredictResponse {
   // Prediction result.
+  // Translation and Text Sentiment will return precisely one payload.
   repeated AnnotationPayload payload = 1;
 
   // Additional domain-specific prediction response metadata.
+  //
+  // * For Image Object Detection:
+  //  `max_bounding_box_count` - (int64) At most that many bounding boxes per
+  //      image could have been returned.
+  //
+  // * For Text Sentiment:
+  //  `sentiment_score` - (float, deprecated) A value between -1 and 1,
+  //      -1 maps to least positive sentiment, while 1 maps to the most positive
+  //      one and the higher the score, the more positive the sentiment in the
+  //      document is. Yet these values are relative to the training data, so
+  //      e.g. if all data was positive then -1 will be also positive (though
+  //      the least).
+  //      The sentiment_score shouldn't be confused with "score" or "magnitude"
+  //      from the previous Natural Language Sentiment Analysis API.
   map<string, string> metadata = 2;
+}
+
+// Request message for [PredictionService.BatchPredict][google.cloud.automl.v1beta1.PredictionService.BatchPredict].
+message BatchPredictRequest {
+  // Name of the model requested to serve the batch prediction.
+  string name = 1;
+
+  // Required. The input configuration for batch prediction.
+  BatchPredictInputConfig input_config = 3;
+
+  // Required. The Configuration specifying where output predictions should
+  // be written.
+  BatchPredictOutputConfig output_config = 4;
+
+  // Additional domain-specific parameters for the predictions, any string must
+  // be up to 25000 characters long.
+  //
+  // *  For Video Classification :
+  //    `score_threshold` - (float) A value from 0.0 to 1.0. When the model
+  //        makes predictions for a video, it will only produce results that
+  //        have at least this confidence score. The default is 0.5.
+  //    `segment_classification` - (boolean) Set to true to request
+  //        segment-level classification. AutoML Video Intelligence returns
+  //        labels and their confidence scores for the entire segment of the
+  //        video that user specified in the request configuration.
+  //        The default is "true".
+  //    `shot_classification` - (boolean) Set to true to request shot-level
+  //        classification. AutoML Video Intelligence determines the boundaries
+  //        for each camera shot in the entire segment of the video that user
+  //        specified in the request configuration. AutoML Video Intelligence
+  //        then returns labels and their confidence scores for each detected
+  //        shot, along with the start and end time of the shot.
+  //        WARNING: Model evaluation is not done for this classification type,
+  //        the quality of it depends on training data, but there are no metrics
+  //        provided to describe that quality. The default is "false".
+  //    `1s_interval_classification` - (boolean) Set to true to request
+  //        classification for a video at one-second intervals. AutoML Video
+  //        Intelligence returns labels and their confidence scores for each
+  //        second of the entire segment of the video that user specified in the
+  //        request configuration.
+  //        WARNING: Model evaluation is not done for this classification
+  //        type, the quality of it depends on training data, but there are no
+  //        metrics provided to describe that quality. The default is
+  //        "false".
+  map<string, string> params = 5;
+}
+
+// Batch predict result.
+message BatchPredictResult {
 }

--- a/protos/google/cloud/automl/v1beta1/ranges.proto
+++ b/protos/google/cloud/automl/v1beta1/ranges.proto
@@ -1,0 +1,36 @@
+// Copyright 2018 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package google.cloud.automl.v1beta1;
+
+import "google/api/annotations.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/cloud/automl/v1beta1;automl";
+option java_multiple_files = true;
+option java_outer_classname = "RangesProto";
+option java_package = "com.google.cloud.automl.v1beta1";
+option php_namespace = "Google\\Cloud\\AutoMl\\V1beta1";
+
+
+// A range between two double numbers.
+message DoubleRange {
+  // Start of the range, inclusive.
+  double start = 1;
+
+  // End of the range, exclusive.
+  double end = 2;
+}

--- a/protos/google/cloud/automl/v1beta1/regression.proto
+++ b/protos/google/cloud/automl/v1beta1/regression.proto
@@ -1,0 +1,42 @@
+// Copyright 2018 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package google.cloud.automl.v1beta1;
+
+import "google/api/annotations.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/cloud/automl/v1beta1;automl";
+option java_outer_classname = "RegressionProto";
+option java_package = "com.google.cloud.automl.v1beta1";
+option php_namespace = "Google\\Cloud\\AutoMl\\V1beta1";
+
+
+// Metrics for regression problems.
+message RegressionEvaluationMetrics {
+  // Output only. Root Mean Squared Error (RMSE).
+  float root_mean_squared_error = 1;
+
+  // Output only. Mean Absolute Error (MAE).
+  float mean_absolute_error = 2;
+
+  // Output only. Mean absolute percentage error. Only set if all ground truth
+  // values are are positive.
+  float mean_absolute_percentage_error = 3;
+
+  // Output only. R squared.
+  float r_squared = 4;
+}

--- a/protos/google/cloud/automl/v1beta1/service.proto
+++ b/protos/google/cloud/automl/v1beta1/service.proto
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
 syntax = "proto3";
 
@@ -18,11 +19,14 @@ package google.cloud.automl.v1beta1;
 
 import "google/api/annotations.proto";
 import "google/cloud/automl/v1beta1/annotation_payload.proto";
+import "google/cloud/automl/v1beta1/column_spec.proto";
 import "google/cloud/automl/v1beta1/dataset.proto";
+import "google/cloud/automl/v1beta1/image.proto";
 import "google/cloud/automl/v1beta1/io.proto";
 import "google/cloud/automl/v1beta1/model.proto";
 import "google/cloud/automl/v1beta1/model_evaluation.proto";
 import "google/cloud/automl/v1beta1/operations.proto";
+import "google/cloud/automl/v1beta1/table_spec.proto";
 import "google/longrunning/operations.proto";
 import "google/protobuf/field_mask.proto";
 
@@ -31,6 +35,7 @@ option java_multiple_files = true;
 option java_outer_classname = "AutoMlProto";
 option java_package = "com.google.cloud.automl.v1beta1";
 option php_namespace = "Google\\Cloud\\AutoMl\\V1beta1";
+
 
 // AutoML Server API.
 //
@@ -42,6 +47,10 @@ option php_namespace = "Google\\Cloud\\AutoMl\\V1beta1";
 // `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}`, then
 // the id for the item is `{dataset_id}`.
 //
+// Currently the only supported `location_id` is "us-central1".
+//
+// On any input that is documented to expect a string parameter in
+// snake_case or kebab-case, either of those cases is accepted.
 service AutoMl {
   // Creates a dataset.
   rpc CreateDataset(CreateDatasetRequest) returns (Dataset) {
@@ -65,19 +74,31 @@ service AutoMl {
     };
   }
 
+  // Updates a dataset.
+  rpc UpdateDataset(UpdateDatasetRequest) returns (Dataset) {
+    option (google.api.http) = {
+      patch: "/v1beta1/{dataset.name=projects/*/locations/*/datasets/*}"
+      body: "dataset"
+    };
+  }
+
   // Deletes a dataset and all of its contents.
   // Returns empty response in the
   // [response][google.longrunning.Operation.response] field when it completes,
   // and `delete_details` in the
   // [metadata][google.longrunning.Operation.metadata] field.
-  rpc DeleteDataset(DeleteDatasetRequest)
-      returns (google.longrunning.Operation) {
+  rpc DeleteDataset(DeleteDatasetRequest) returns (google.longrunning.Operation) {
     option (google.api.http) = {
       delete: "/v1beta1/{name=projects/*/locations/*/datasets/*}"
     };
   }
 
-  // Imports data into a dataset.
+  // Imports data into a dataset. For Tables this method can only be called on an empty Dataset.
+  //
+  // For Tables:
+  // *   A
+  // [schema_inference_version][google.cloud.automl.v1beta1.InputConfig.params]
+  //     parameter must be explicitly set.
   // Returns an empty response in the
   // [response][google.longrunning.Operation.response] field when it completes.
   rpc ImportData(ImportDataRequest) returns (google.longrunning.Operation) {
@@ -87,13 +108,64 @@ service AutoMl {
     };
   }
 
-  // Exports dataset's data to a Google Cloud Storage bucket.
+  // Exports dataset's data to the provided output location.
   // Returns an empty response in the
   // [response][google.longrunning.Operation.response] field when it completes.
   rpc ExportData(ExportDataRequest) returns (google.longrunning.Operation) {
     option (google.api.http) = {
       post: "/v1beta1/{name=projects/*/locations/*/datasets/*}:exportData"
       body: "*"
+    };
+  }
+
+  // Gets an annotation spec.
+  rpc GetAnnotationSpec(GetAnnotationSpecRequest) returns (AnnotationSpec) {
+    option (google.api.http) = {
+      get: "/v1beta1/{name=projects/*/locations/*/datasets/*/annotationSpecs/*}"
+    };
+  }
+
+  // Gets a table spec.
+  rpc GetTableSpec(GetTableSpecRequest) returns (TableSpec) {
+    option (google.api.http) = {
+      get: "/v1beta1/{name=projects/*/locations/*/datasets/*/tableSpecs/*}"
+    };
+  }
+
+  // Lists table specs in a dataset.
+  rpc ListTableSpecs(ListTableSpecsRequest) returns (ListTableSpecsResponse) {
+    option (google.api.http) = {
+      get: "/v1beta1/{parent=projects/*/locations/*/datasets/*}/tableSpecs"
+    };
+  }
+
+  // Updates a table spec.
+  rpc UpdateTableSpec(UpdateTableSpecRequest) returns (TableSpec) {
+    option (google.api.http) = {
+      patch: "/v1beta1/{table_spec.name=projects/*/locations/*/datasets/*/tableSpecs/*}"
+      body: "table_spec"
+    };
+  }
+
+  // Gets a column spec.
+  rpc GetColumnSpec(GetColumnSpecRequest) returns (ColumnSpec) {
+    option (google.api.http) = {
+      get: "/v1beta1/{name=projects/*/locations/*/datasets/*/tableSpecs/*/columnSpecs/*}"
+    };
+  }
+
+  // Lists column specs in a table spec.
+  rpc ListColumnSpecs(ListColumnSpecsRequest) returns (ListColumnSpecsResponse) {
+    option (google.api.http) = {
+      get: "/v1beta1/{parent=projects/*/locations/*/datasets/*/tableSpecs/*}/columnSpecs"
+    };
+  }
+
+  // Updates a column spec.
+  rpc UpdateColumnSpec(UpdateColumnSpecRequest) returns (ColumnSpec) {
+    option (google.api.http) = {
+      patch: "/v1beta1/{column_spec.name=projects/*/locations/*/datasets/*/tableSpecs/*/columnSpecs/*}"
+      body: "column_spec"
     };
   }
 
@@ -124,9 +196,6 @@ service AutoMl {
   }
 
   // Deletes a model.
-  // If a model is already deployed, this only deletes the model in AutoML BE,
-  // and does not change the status of the deployed model in the production
-  // environment.
   // Returns `google.protobuf.Empty` in the
   // [response][google.longrunning.Operation.response] field when it completes,
   // and `delete_details` in the
@@ -137,8 +206,17 @@ service AutoMl {
     };
   }
 
-  // Deploys model.
-  // Returns a [DeployModelResponse][] in the
+  // Deploys a model. If a model is already deployed, deploying it with the
+  // same parameters has no effect. Deploying with different parametrs
+  // (as e.g. changing
+  //
+  // [node_number][google.cloud.automl.v1beta1.ImageObjectDetectionModelDeploymentMetadata.node_number]
+  // ) will update the deployment without pausing the model's availability.
+  //
+  // Only applicable for Text Classification, Image Object Detection and Tables;
+  // all other domains manage deployment automatically.
+  //
+  // Returns an empty response in the
   // [response][google.longrunning.Operation.response] field when it completes.
   rpc DeployModel(DeployModelRequest) returns (google.longrunning.Operation) {
     option (google.api.http) = {
@@ -147,13 +225,52 @@ service AutoMl {
     };
   }
 
-  // Undeploys model.
-  // Returns an `UndeployModelResponse` in the
+  // Undeploys a model. If the model is not deployed this method has no effect.
+  //
+  // Only applicable for Text Classification, Image Object Detection and Tables;
+  // all other domains manage deployment automatically.
+  //
+  // Returns an empty response in the
   // [response][google.longrunning.Operation.response] field when it completes.
-  rpc UndeployModel(UndeployModelRequest)
-      returns (google.longrunning.Operation) {
+  rpc UndeployModel(UndeployModelRequest) returns (google.longrunning.Operation) {
     option (google.api.http) = {
       post: "/v1beta1/{name=projects/*/locations/*/models/*}:undeploy"
+      body: "*"
+    };
+  }
+
+  // Exports a trained, "export-able", model to a user specified Google Cloud
+  // Storage location. A model is considered export-able if and only if it has
+  // an export format defined for it in
+  //
+  // [ModelExportOutputConfig][google.cloud.automl.v1beta1.ModelExportOutputConfig].
+  //
+  // Returns an empty response in the
+  // [response][google.longrunning.Operation.response] field when it completes.
+  rpc ExportModel(ExportModelRequest) returns (google.longrunning.Operation) {
+    option (google.api.http) = {
+      post: "/v1beta1/{name=projects/*/locations/*/models/*}:export"
+      body: "*"
+    };
+  }
+
+  // Exports examples on which the model was evaluated (i.e. which were in the
+  // TEST set of the dataset the model was created from), together with their
+  // ground truth annotations and the annotations created (predicted) by the
+  // model.
+  // The examples, ground truth and predictions are exported in the state
+  // they were at the moment the model was evaluated.
+  //
+  // This export is available only for 30 days since the model evaluation is
+  // created.
+  //
+  // Currently only available for Tables.
+  //
+  // Returns an empty response in the
+  // [response][google.longrunning.Operation.response] field when it completes.
+  rpc ExportEvaluatedExamples(ExportEvaluatedExamplesRequest) returns (google.longrunning.Operation) {
+    option (google.api.http) = {
+      post: "/v1beta1/{name=projects/*/locations/*/models/*}:exportEvaluatedExamples"
       body: "*"
     };
   }
@@ -166,16 +283,14 @@ service AutoMl {
   }
 
   // Lists model evaluations.
-  rpc ListModelEvaluations(ListModelEvaluationsRequest)
-      returns (ListModelEvaluationsResponse) {
+  rpc ListModelEvaluations(ListModelEvaluationsRequest) returns (ListModelEvaluationsResponse) {
     option (google.api.http) = {
       get: "/v1beta1/{parent=projects/*/locations/*/models/*}/modelEvaluations"
     };
   }
 }
 
-// Request message for
-// [AutoMl.CreateDataset][google.cloud.automl.v1beta1.AutoMl.CreateDataset].
+// Request message for [AutoMl.CreateDataset][google.cloud.automl.v1beta1.AutoMl.CreateDataset].
 message CreateDatasetRequest {
   // The resource name of the project to create the dataset for.
   string parent = 1;
@@ -184,24 +299,21 @@ message CreateDatasetRequest {
   Dataset dataset = 2;
 }
 
-// Request message for
-// [AutoMl.GetDataset][google.cloud.automl.v1beta1.AutoMl.GetDataset].
+// Request message for [AutoMl.GetDataset][google.cloud.automl.v1beta1.AutoMl.GetDataset].
 message GetDatasetRequest {
   // The resource name of the dataset to retrieve.
   string name = 1;
 }
 
-// Request message for
-// [AutoMl.ListDatasets][google.cloud.automl.v1beta1.AutoMl.ListDatasets].
+// Request message for [AutoMl.ListDatasets][google.cloud.automl.v1beta1.AutoMl.ListDatasets].
 message ListDatasetsRequest {
   // The resource name of the project from which to list datasets.
   string parent = 1;
 
   // An expression for filtering the results of the request.
   //
-  //   * `dataset_metadata` - for existence of the case.
-  //
-  // An example of using the filter is:
+  //   * `dataset_metadata` - for existence of the case (e.g.
+  //             image_classification_dataset_metadata:*). Some examples of using the filter are:
   //
   //   * `translation_dataset_metadata:*` --> The dataset has
   //                                          translation_dataset_metadata.
@@ -213,46 +325,53 @@ message ListDatasetsRequest {
 
   // A token identifying a page of results for the server to return
   // Typically obtained via
-  // [ListDatasetsResponse.next_page_token][google.cloud.automl.v1beta1.ListDatasetsResponse.next_page_token]
-  // of the previous
-  // [AutoMl.ListDatasets][google.cloud.automl.v1beta1.AutoMl.ListDatasets]
-  // call.
+  // [ListDatasetsResponse.next_page_token][google.cloud.automl.v1beta1.ListDatasetsResponse.next_page_token] of the previous
+  // [AutoMl.ListDatasets][google.cloud.automl.v1beta1.AutoMl.ListDatasets] call.
   string page_token = 6;
 }
 
-// Response message for
-// [AutoMl.ListDatasets][google.cloud.automl.v1beta1.AutoMl.ListDatasets].
+// Response message for [AutoMl.ListDatasets][google.cloud.automl.v1beta1.AutoMl.ListDatasets].
 message ListDatasetsResponse {
   // The datasets read.
   repeated Dataset datasets = 1;
 
   // A token to retrieve next page of results.
-  // Pass to
-  // [ListDatasetsRequest.page_token][google.cloud.automl.v1beta1.ListDatasetsRequest.page_token]
-  // to obtain that page.
+  // Pass to [ListDatasetsRequest.page_token][google.cloud.automl.v1beta1.ListDatasetsRequest.page_token] to obtain that page.
   string next_page_token = 2;
 }
 
-// Request message for
-// [AutoMl.DeleteDataset][google.cloud.automl.v1beta1.AutoMl.DeleteDataset].
+// Request message for [AutoMl.UpdateDataset][google.cloud.automl.v1beta1.AutoMl.UpdateDataset]
+message UpdateDatasetRequest {
+  // The dataset which replaces the resource on the server.
+  Dataset dataset = 1;
+
+  // The update mask applies to the resource. For the `FieldMask` definition,
+  // see
+  //
+  // https:
+  // //developers.google.com/protocol-buffers
+  // // /docs/reference/google.protobuf#fieldmask
+  google.protobuf.FieldMask update_mask = 2;
+}
+
+// Request message for [AutoMl.DeleteDataset][google.cloud.automl.v1beta1.AutoMl.DeleteDataset].
 message DeleteDatasetRequest {
   // The resource name of the dataset to delete.
   string name = 1;
 }
 
-// Request message for
-// [AutoMl.ImportData][google.cloud.automl.v1beta1.AutoMl.ImportData].
+// Request message for [AutoMl.ImportData][google.cloud.automl.v1beta1.AutoMl.ImportData].
 message ImportDataRequest {
   // Required. Dataset name. Dataset must already exist. All imported
   // annotations and examples will be added.
   string name = 1;
 
-  // Required. The desired input location.
+  // Required. The desired input location and its domain specific semantics,
+  // if any.
   InputConfig input_config = 3;
 }
 
-// Request message for
-// [AutoMl.ExportData][google.cloud.automl.v1beta1.AutoMl.ExportData].
+// Request message for [AutoMl.ExportData][google.cloud.automl.v1beta1.AutoMl.ExportData].
 message ExportDataRequest {
   // Required. The resource name of the dataset.
   string name = 1;
@@ -261,8 +380,123 @@ message ExportDataRequest {
   OutputConfig output_config = 3;
 }
 
-// Request message for
-// [AutoMl.CreateModel][google.cloud.automl.v1beta1.AutoMl.CreateModel].
+// Request message for [AutoMl.GetAnnotationSpec][google.cloud.automl.v1beta1.AutoMl.GetAnnotationSpec].
+message GetAnnotationSpecRequest {
+  // The resource name of the annotation spec to retrieve.
+  string name = 1;
+}
+
+// Request message for [AutoMl.GetTableSpec][google.cloud.automl.v1beta1.AutoMl.GetTableSpec].
+message GetTableSpecRequest {
+  // The resource name of the table spec to retrieve.
+  string name = 1;
+
+  // Mask specifying which fields to read.
+  google.protobuf.FieldMask field_mask = 2;
+}
+
+// Request message for [AutoMl.ListTableSpecs][google.cloud.automl.v1beta1.AutoMl.ListTableSpecs].
+message ListTableSpecsRequest {
+  // The resource name of the dataset to list table specs from.
+  string parent = 1;
+
+  // Mask specifying which fields to read.
+  google.protobuf.FieldMask field_mask = 2;
+
+  // Filter expression, see go/filtering.
+  string filter = 3;
+
+  // Requested page size. The server can return fewer results than requested.
+  // If unspecified, the server will pick a default size.
+  int32 page_size = 4;
+
+  // A token identifying a page of results for the server to return.
+  // Typically obtained from the
+  // [ListTableSpecsResponse.next_page_token][google.cloud.automl.v1beta1.ListTableSpecsResponse.next_page_token] field of the previous
+  // [AutoMl.ListTableSpecs][google.cloud.automl.v1beta1.AutoMl.ListTableSpecs] call.
+  string page_token = 6;
+}
+
+// Response message for [AutoMl.ListTableSpecs][google.cloud.automl.v1beta1.AutoMl.ListTableSpecs].
+message ListTableSpecsResponse {
+  // The table specs read.
+  repeated TableSpec table_specs = 1;
+
+  // A token to retrieve next page of results.
+  // Pass to [ListTableSpecsRequest.page_token][google.cloud.automl.v1beta1.ListTableSpecsRequest.page_token] to obtain that page.
+  string next_page_token = 2;
+}
+
+// Request message for [AutoMl.UpdateTableSpec][google.cloud.automl.v1beta1.AutoMl.UpdateTableSpec]
+message UpdateTableSpecRequest {
+  // The table spec which replaces the resource on the server.
+  TableSpec table_spec = 1;
+
+  // The update mask applies to the resource. For the `FieldMask` definition,
+  // see
+  //
+  // https:
+  // //developers.google.com/protocol-buffers
+  // // /docs/reference/google.protobuf#fieldmask
+  google.protobuf.FieldMask update_mask = 2;
+}
+
+// Request message for [AutoMl.GetColumnSpec][google.cloud.automl.v1beta1.AutoMl.GetColumnSpec].
+message GetColumnSpecRequest {
+  // The resource name of the column spec to retrieve.
+  string name = 1;
+
+  // Mask specifying which fields to read.
+  google.protobuf.FieldMask field_mask = 2;
+}
+
+// Request message for [AutoMl.ListColumnSpecs][google.cloud.automl.v1beta1.AutoMl.ListColumnSpecs].
+message ListColumnSpecsRequest {
+  // The resource name of the table spec to list column specs from.
+  string parent = 1;
+
+  // Mask specifying which fields to read.
+  google.protobuf.FieldMask field_mask = 2;
+
+  // Filter expression, see go/filtering.
+  string filter = 3;
+
+  // Requested page size. The server can return fewer results than requested.
+  // If unspecified, the server will pick a default size.
+  int32 page_size = 4;
+
+  // A token identifying a page of results for the server to return.
+  // Typically obtained from the
+  // [ListColumnSpecsResponse.next_page_token][google.cloud.automl.v1beta1.ListColumnSpecsResponse.next_page_token] field of the previous
+  // [AutoMl.ListColumnSpecs][google.cloud.automl.v1beta1.AutoMl.ListColumnSpecs] call.
+  string page_token = 6;
+}
+
+// Response message for [AutoMl.ListColumnSpecs][google.cloud.automl.v1beta1.AutoMl.ListColumnSpecs].
+message ListColumnSpecsResponse {
+  // The column specs read.
+  repeated ColumnSpec column_specs = 1;
+
+  // A token to retrieve next page of results.
+  // Pass to [ListColumnSpecsRequest.page_token][google.cloud.automl.v1beta1.ListColumnSpecsRequest.page_token] to obtain that page.
+  string next_page_token = 2;
+}
+
+// Request message for [AutoMl.UpdateColumnSpec][google.cloud.automl.v1beta1.AutoMl.UpdateColumnSpec]
+message UpdateColumnSpecRequest {
+  // The column spec which replaces the resource on the server.
+  ColumnSpec column_spec = 1;
+
+  // The update mask applies to the resource. For the `FieldMask` definition,
+  // see
+  //
+  // https:
+  // //developers.google.com/protocol-buffers
+  // // /docs/reference/google.protobuf#fieldmask
+  google.protobuf.FieldMask update_mask = 2;
+}
+
+// Request message for [AutoMl.CreateModel][google.cloud.automl.v1beta1.AutoMl.CreateModel].
 message CreateModelRequest {
   // Resource name of the parent project where the model is being created.
   string parent = 1;
@@ -271,30 +505,26 @@ message CreateModelRequest {
   Model model = 4;
 }
 
-// Request message for
-// [AutoMl.GetModel][google.cloud.automl.v1beta1.AutoMl.GetModel].
+// Request message for [AutoMl.GetModel][google.cloud.automl.v1beta1.AutoMl.GetModel].
 message GetModelRequest {
   // Resource name of the model.
   string name = 1;
 }
 
-// Request message for
-// [AutoMl.ListModels][google.cloud.automl.v1beta1.AutoMl.ListModels].
+// Request message for [AutoMl.ListModels][google.cloud.automl.v1beta1.AutoMl.ListModels].
 message ListModelsRequest {
   // Resource name of the project, from which to list the models.
   string parent = 1;
 
   // An expression for filtering the results of the request.
   //
-  //   * `model_metadata` - for existence of the case.
-  //   * `dataset_id` - for = or !=.
-  //
-  // Some examples of using the filter are:
+  //   * `model_metadata` - for existence of the case (e.g.
+  //             video_classification_model_metadata:*).
+  //   * `dataset_id` - for = or !=. Some examples of using the filter are:
   //
   //   * `image_classification_model_metadata:*` --> The model has
   //                                        image_classification_model_metadata.
-  //   * `dataset_id=5` --> The model was created from a sibling dataset with
-  //                    ID 5.
+  //   * `dataset_id=5` --> The model was created from a dataset with ID 5.
   string filter = 3;
 
   // Requested page size.
@@ -302,53 +532,73 @@ message ListModelsRequest {
 
   // A token identifying a page of results for the server to return
   // Typically obtained via
-  // [ListModelsResponse.next_page_token][google.cloud.automl.v1beta1.ListModelsResponse.next_page_token]
-  // of the previous
+  // [ListModelsResponse.next_page_token][google.cloud.automl.v1beta1.ListModelsResponse.next_page_token] of the previous
   // [AutoMl.ListModels][google.cloud.automl.v1beta1.AutoMl.ListModels] call.
   string page_token = 6;
 }
 
-// Response message for
-// [AutoMl.ListModels][google.cloud.automl.v1beta1.AutoMl.ListModels].
+// Response message for [AutoMl.ListModels][google.cloud.automl.v1beta1.AutoMl.ListModels].
 message ListModelsResponse {
   // List of models in the requested page.
   repeated Model model = 1;
 
   // A token to retrieve next page of results.
-  // Pass to [ListModels.page_token][] to obtain that page.
+  // Pass to [ListModelsRequest.page_token][google.cloud.automl.v1beta1.ListModelsRequest.page_token] to obtain that page.
   string next_page_token = 2;
 }
 
-// Request message for
-// [AutoMl.DeleteModel][google.cloud.automl.v1beta1.AutoMl.DeleteModel].
+// Request message for [AutoMl.DeleteModel][google.cloud.automl.v1beta1.AutoMl.DeleteModel].
 message DeleteModelRequest {
   // Resource name of the model being deleted.
   string name = 1;
 }
 
-// Request message for
-// [AutoMl.DeployModel][google.cloud.automl.v1beta1.AutoMl.DeployModel].
+// Request message for [AutoMl.DeployModel][google.cloud.automl.v1beta1.AutoMl.DeployModel].
 message DeployModelRequest {
+  // The per-domain specific deployment parameters.
+  oneof model_deployment_metadata {
+    // Model deployment metadata specific to Image Object Detection.
+    ImageObjectDetectionModelDeploymentMetadata image_object_detection_model_deployment_metadata = 2;
+  }
+
   // Resource name of the model to deploy.
   string name = 1;
 }
 
-// Request message for
-// [AutoMl.UndeployModel][google.cloud.automl.v1beta1.AutoMl.UndeployModel].
+// Request message for [AutoMl.UndeployModel][google.cloud.automl.v1beta1.AutoMl.UndeployModel].
 message UndeployModelRequest {
   // Resource name of the model to undeploy.
   string name = 1;
 }
 
-// Request message for
-// [AutoMl.GetModelEvaluation][google.cloud.automl.v1beta1.AutoMl.GetModelEvaluation].
+// Request message for [AutoMl.ExportModel][google.cloud.automl.v1beta1.AutoMl.ExportModel].
+// Models need to be enabled for exporting, otherwise an error code will be
+// returned.
+message ExportModelRequest {
+  // Required. The resource name of the model to export.
+  string name = 1;
+
+  // Required. The desired output location and configuration.
+  ModelExportOutputConfig output_config = 3;
+}
+
+// Request message for [AutoMl.ExportEvaluatedExamples][google.cloud.automl.v1beta1.AutoMl.ExportEvaluatedExamples].
+message ExportEvaluatedExamplesRequest {
+  // Required. The resource name of the model whose evaluated examples are to
+  // be exported.
+  string name = 1;
+
+  // Required. The desired output location and configuration.
+  ExportEvaluatedExamplesOutputConfig output_config = 3;
+}
+
+// Request message for [AutoMl.GetModelEvaluation][google.cloud.automl.v1beta1.AutoMl.GetModelEvaluation].
 message GetModelEvaluationRequest {
   // Resource name for the model evaluation.
   string name = 1;
 }
 
-// Request message for
-// [AutoMl.ListModelEvaluations][google.cloud.automl.v1beta1.AutoMl.ListModelEvaluations].
+// Request message for [AutoMl.ListModelEvaluations][google.cloud.automl.v1beta1.AutoMl.ListModelEvaluations].
 message ListModelEvaluationsRequest {
   // Resource name of the model to list the model evaluations for.
   // If modelId is set as "-", this will list model evaluations from across all
@@ -373,19 +623,18 @@ message ListModelEvaluationsRequest {
 
   // A token identifying a page of results for the server to return.
   // Typically obtained via
-  // `ListModelEvaluationsResponse.next_page_token` of the previous
-  // [AutoMl.ListModelEvaluations][google.cloud.automl.v1beta1.AutoMl.ListModelEvaluations]
-  // call.
+  // [ListModelEvaluationsResponse.next_page_token][google.cloud.automl.v1beta1.ListModelEvaluationsResponse.next_page_token] of the previous
+  // [AutoMl.ListModelEvaluations][google.cloud.automl.v1beta1.AutoMl.ListModelEvaluations] call.
   string page_token = 6;
 }
 
-// Response message for
-// [AutoMl.ListModelEvaluations][google.cloud.automl.v1beta1.AutoMl.ListModelEvaluations].
+// Response message for [AutoMl.ListModelEvaluations][google.cloud.automl.v1beta1.AutoMl.ListModelEvaluations].
 message ListModelEvaluationsResponse {
   // List of model evaluations in the requested page.
   repeated ModelEvaluation model_evaluation = 1;
 
   // A token to retrieve next page of results.
-  // Pass to [ListModelEvaluations.page_token][] to obtain that page.
+  // Pass to the [ListModelEvaluationsRequest.page_token][google.cloud.automl.v1beta1.ListModelEvaluationsRequest.page_token] field of a new
+  // [AutoMl.ListModelEvaluations][google.cloud.automl.v1beta1.AutoMl.ListModelEvaluations] request to obtain that page.
   string next_page_token = 2;
 }

--- a/protos/google/cloud/automl/v1beta1/table_spec.proto
+++ b/protos/google/cloud/automl/v1beta1/table_spec.proto
@@ -1,0 +1,69 @@
+// Copyright 2018 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package google.cloud.automl.v1beta1;
+
+import "google/api/annotations.proto";
+import "google/cloud/automl/v1beta1/io.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/cloud/automl/v1beta1;automl";
+option java_multiple_files = true;
+option java_package = "com.google.cloud.automl.v1beta1";
+option php_namespace = "Google\\Cloud\\AutoMl\\V1beta1";
+
+
+// A specification of a relational table.
+// The table's schema is represented via its child column specs. It is
+// pre-populated as part of ImportData by schema inference algorithm, the
+// version of which is a required parameter of ImportData InputConfig.
+// Note: While working with a table, at times the schema may be
+// inconsistent with the data in the table (e.g. string in a FLOAT64 column).
+// The consistency validation is done upon creation of a model.
+// Used by:
+//   *   Tables
+message TableSpec {
+  // Output only. The resource name of the table spec.
+  // Form:
+  //
+  // `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/tableSpecs/{table_spec_id}`
+  string name = 1;
+
+  // column_spec_id of the time column. Only used if the parent dataset's
+  // ml_use_column_spec_id is not set. Used to split rows into TRAIN, VALIDATE
+  // and TEST sets such that oldest rows go to TRAIN set, newest to TEST, and
+  // those in between to VALIDATE.
+  // Required type: TIMESTAMP.
+  // If both this column and ml_use_column are not set, then ML use of all rows
+  // will be assigned by AutoML. NOTE: Updates of this field will instantly
+  // affect any other users concurrently working with the dataset.
+  string time_column_spec_id = 2;
+
+  // Output only. The number of rows (i.e. examples) in the table.
+  int64 row_count = 3;
+
+  // Output only. The number of columns of the table. That is, the number of
+  // child ColumnSpec-s.
+  int64 column_count = 7;
+
+  // Output only. Input configs via which data currently residing in the table
+  // had been imported.
+  repeated InputConfig input_configs = 5;
+
+  // Used to perform consistent read-modify-write updates. If not set, a blind
+  // "overwrite" update happens.
+  string etag = 6;
+}

--- a/protos/google/cloud/automl/v1beta1/tables.proto
+++ b/protos/google/cloud/automl/v1beta1/tables.proto
@@ -1,0 +1,251 @@
+// Copyright 2018 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package google.cloud.automl.v1beta1;
+
+import "google/api/annotations.proto";
+import "google/cloud/automl/v1beta1/column_spec.proto";
+import "google/cloud/automl/v1beta1/data_stats.proto";
+import "google/cloud/automl/v1beta1/ranges.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/cloud/automl/v1beta1;automl";
+option java_multiple_files = true;
+option java_package = "com.google.cloud.automl.v1beta1";
+option php_namespace = "Google\\Cloud\\AutoMl\\V1beta1";
+
+
+// Metadata for a dataset used for AutoML Tables.
+message TablesDatasetMetadata {
+  // Output only. The table_spec_id of the primary table of this dataset.
+  string primary_table_spec_id = 1;
+
+  // column_spec_id of the primary table's column that should be used as the
+  // training & prediction target.
+  // This column must be non-nullable and have one of following data types
+  // (otherwise model creation will error):
+  // * CATEGORY
+  // * ARRAY(CATEGORY)
+  // * FLOAT64
+  // Furthermore, if the type is CATEGORY or ARRAY(CATEGORY), then only up to
+  // 40 unique values may exist in that column across all rows, but for
+  // ARRAY(CATEGORY) unique values are counted as elements of the ARRAY (i.e.
+  // following 3 ARRAY-s: [A, B], [A], [B] are counted as having 2 unique
+  // values).
+  //
+  // NOTE: Updates of this field will instantly affect any other users
+  // concurrently working with the dataset.
+  string target_column_spec_id = 2;
+
+  // column_spec_id of the primary table's column that should be used as the
+  // weight column, i.e. the higher the value the more important the row will be
+  // during model training.
+  // Required type: FLOAT64.
+  // Allowed values: 0 to 10000, inclusive on both ends; 0 means the row is
+  //                 ignored for training.
+  // If not set all rows are assumed to have equal weight of 1.
+  // NOTE: Updates of this field will instantly affect any other users
+  // concurrently working with the dataset.
+  string weight_column_spec_id = 3;
+
+  // column_spec_id of the primary table column which specifies a possible ML
+  // use of the row, i.e. the column will be used to split the rows into TRAIN,
+  // VALIDATE and TEST sets.
+  // Required type: STRING.
+  // This column, if set, must either have all of `TRAIN`, `VALIDATE`, `TEST`
+  // among its values, or only have `TEST`, `UNASSIGNED` values. In the latter
+  // case the rows with `UNASSIGNED` value will be assigned by AutoML. Note
+  // that if a given ml use distribution makes it impossible to create a "good"
+  // model, that call will error describing the issue.
+  // If both this column_spec_id and primary table's time_column_spec_id are not
+  // set, then all rows are treated as `UNASSIGNED`.
+  // NOTE: Updates of this field will instantly affect any other users
+  // concurrently working with the dataset.
+  string ml_use_column_spec_id = 4;
+
+  // Output only. Correlations between
+  //
+  // [target_column][google.cloud.automl.v1beta1.TablesDatasetMetadata.target_column],
+  // and other columns of the
+  //
+  // [primary_table][google.cloud.automl.v1beta1.TablesDatasetMetadata.primary_table_spec_id].
+  // Only set if the target column is set. Mapping from other column spec id to
+  // its CorrelationStats with the target column.
+  // This field may be stale, see the stats_update_time field for
+  // for the timestamp at which these stats were last updated.
+  map<string, CorrelationStats> target_column_correlations = 6;
+
+  // The most recent timestamp when target_column_correlations field and all
+  // descendant ColumnSpec.data_stats and ColumnSpec.top_correlated_columns
+  // fields were last (re-)generated. Any changes that happened to the dataset
+  // afterwards are not reflected in these fields values. The regeneration
+  // happens in the background on a best effort basis.
+  google.protobuf.Timestamp stats_update_time = 7;
+}
+
+// Model metadata specific to AutoML Tables.
+message TablesModelMetadata {
+  // Column spec of the dataset's primary table's column the model is
+  // predicting. Snapshotted when model creation started.
+  // Only 3 fields are used:
+  // name - May be set on CreateModel, if it's not then the ColumnSpec
+  //        corresponding to the current target_column_spec_id of the dataset
+  //        the model is trained from is used.
+  //        If neither is set, CreateModel will error.
+  // display_name - Output only.
+  // data_type - Output only.
+  ColumnSpec target_column_spec = 2;
+
+  // Column specs of the dataset's primary table's columns, on which
+  // the model is trained and which are used as the input for predictions.
+  // The
+  //
+  // [target_column][google.cloud.automl.v1beta1.TablesModelMetadata.target_column_spec]
+  // as well as, according to dataset's state upon model creation,
+  //
+  // [weight_column][google.cloud.automl.v1beta1.TablesDatasetMetadata.weight_column_spec_id],
+  // and
+  //
+  // [ml_use_column][google.cloud.automl.v1beta1.TablesDatasetMetadata.ml_use_column_spec_id]
+  // must never be included here.
+  // Only 3 fields are used:
+  // name - May be set on CreateModel, if set only the columns specified are
+  //        used, otherwise all primary table's columns (except the ones listed
+  //        above) are used for the training and prediction input.
+  // display_name - Output only.
+  // data_type - Output only.
+  repeated ColumnSpec input_feature_column_specs = 3;
+
+  // Objective function the model is optimizing towards. The training process
+  // creates a model that maximizes/minimizes the value of the objective
+  // function over the validation set.
+  //
+  // The supported optimization objectives depend on the prediction_type.
+  // If the field is not set, a default objective function is used.
+  //
+  // CLASSIFICATION_BINARY:
+  //   "MAXIMIZE_AU_ROC" (default) - Maximize the area under the receiver
+  //                                 operating characteristic (ROC) curve.
+  //   "MINIMIZE_LOG_LOSS" - Minimize log loss.
+  //   "MAXIMIZE_AU_PRC" - Maximize the area under the precision-recall curve.
+  //
+  // CLASSIFICATION_MULTI_CLASS :
+  //   "MINIMIZE_LOG_LOSS" (default) - Minimize log loss.
+  //
+  // CLASSIFICATION_MULTI_LABEL:
+  //   "MINIMIZE_LOG_LOSS" (default) - Minimize log loss.
+  //
+  // REGRESSION:
+  //   "MINIMIZE_RMSE" (default) - Minimize root-mean-squared error (RMSE).
+  //   "MINIMIZE_MAE" - Minimize mean-absolute error (MAE).
+  //   "MINIMIZE_RMSLE" - Minimize root-mean-squared log error (RMSLE).
+  //
+  // FORECASTING:
+  //   "MINIMIZE_RMSE" (default) - Minimize root-mean-squared error (RMSE).
+  //   "MINIMIZE_MAE" - Minimize mean-absolute error (MAE).
+  string optimization_objective = 4;
+
+  // Output only. Auxiliary information for each of the
+  // input_feature_column_specs, with respect to this particular model.
+  repeated TablesModelColumnInfo tables_model_column_info = 5;
+
+  // The train budget of creating this model, expressed in milli node hours
+  // i.e. 1,000 value in this field means 1 node hour.
+  //
+  // The training cost of the model will not exceed this budget. The final cost
+  // will be attempted to be close to the budget, though may end up being (even)
+  // noticeably smaller - at the backend's discretion. This especially may
+  // happen when further model training ceases to provide any improvements.
+  //
+  // If the budget is set to a value known to be insufficient to train a
+  // model for the given dataset, the training won't be attempted and
+  // will error.
+  int64 train_budget_milli_node_hours = 6;
+
+  // Output only. The actual training cost of the model, expressed in milli
+  // node hours, i.e. 1,000 value in this field means 1 node hour. Guaranteed
+  // to not exceed the train budget.
+  int64 train_cost_milli_node_hours = 7;
+}
+
+// Contains annotation details specific to Tables.
+message TablesAnnotation {
+  // Output only. A confidence estimate between 0.0 and 1.0, inclusive. A higher
+  // value means greater confidence in the returned value.
+  // For
+  //
+  // [target_column_spec][google.cloud.automl.v1beta1.TablesModelMetadata.target_column_spec]
+  // of ARRAY(CATEGORY) data type, this is a confidence that one of the values
+  // in the ARRAY would be the provided value.
+  // For
+  //
+  // [target_column_spec][google.cloud.automl.v1beta1.TablesModelMetadata.target_column_spec]
+  // of FLOAT64 data type the score is not populated.
+  float score = 1;
+
+  // Output only. Only populated when
+  //
+  // [target_column_spec][google.cloud.automl.v1beta1.TablesModelMetadata.target_column_spec]
+  // has FLOAT64 data type (i.e. for regression predictions). An interval in
+  // which the exactly correct target value has 95% chance to be in.
+  DoubleRange prediction_interval = 4;
+
+  // The predicted value of the row's
+  //
+  // [target_column][google.cloud.automl.v1beta1.TablesModelMetadata.target_column_spec].
+  // The value depends on the column's DataType:
+  // CATEGORY - the predicted (with the above confidence `score`) CATEGORY
+  //            value.
+  // FLOAT64 - the predicted (with the above confidence `score`) FLOAT64 value.
+  // ARRAY(CATEGORY) - CATEGORY value meaning that this value would be in the
+  //                   ARRAY in that column (with the above confidence `score`).
+  google.protobuf.Value value = 2;
+
+  // Output only. Auxiliary information for each of the model's
+  //
+  // [input_feature_column_specs'][google.cloud.automl.v1beta1.TablesModelMetadata.input_feature_column_specs]
+  // with respect to this particular prediction.
+  repeated TablesModelColumnInfo tables_model_column_info = 3;
+}
+
+// An information specific to given column and Tables Model, in context
+// of the Model and the predictions created by it.
+message TablesModelColumnInfo {
+  // Output only. The name of the ColumnSpec describing the column. Not
+  // populated when this proto is outputted to BigQuery.
+  string column_spec_name = 1;
+
+  // Output only. The display name of the column (same as the display_name of
+  // its ColumnSpec).
+  string column_display_name = 2;
+
+  // Output only.
+  //
+  // When given as part of a Model:
+  // Measurement of how much model predictions correctness on the TEST data
+  // depend on values in this column. A value between 0 and 1, higher means
+  // higher influence. These values are normalized - for all input feature
+  // columns of a given model they add to 1.
+  //
+  // When given back by Predict or Batch Predict:
+  // Measurement of how impactful for the prediction returned for the given row
+  // the value in this column was. A value between 0 and 1, higher means larger
+  // impact. These values are normalized - for all input feature columns of a
+  // single predicted row they add to 1.
+  float feature_importance = 3;
+}

--- a/protos/google/cloud/automl/v1beta1/temporal.proto
+++ b/protos/google/cloud/automl/v1beta1/temporal.proto
@@ -1,0 +1,38 @@
+// Copyright 2018 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package google.cloud.automl.v1beta1;
+
+import "google/api/annotations.proto";
+import "google/protobuf/duration.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/cloud/automl/v1beta1;automl";
+option java_multiple_files = true;
+option java_package = "com.google.cloud.automl.v1beta1";
+option php_namespace = "Google\\Cloud\\AutoMl\\V1beta1";
+
+
+// A time period inside of an example that has a time dimension (e.g. video).
+message TimeSegment {
+  // Start of the time segment (inclusive), represented as the duration since
+  // the example start.
+  google.protobuf.Duration start_time_offset = 1;
+
+  // End of the time segment (exclusive), represented as the duration since the
+  // example start.
+  google.protobuf.Duration end_time_offset = 2;
+}

--- a/protos/google/cloud/automl/v1beta1/text.proto
+++ b/protos/google/cloud/automl/v1beta1/text.proto
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
 syntax = "proto3";
 
@@ -25,6 +26,7 @@ option java_outer_classname = "TextProto";
 option java_package = "com.google.cloud.automl.v1beta1";
 option php_namespace = "Google\\Cloud\\AutoMl\\V1beta1";
 
+
 // Dataset metadata for classification.
 message TextClassificationDatasetMetadata {
   // Required.
@@ -33,4 +35,33 @@ message TextClassificationDatasetMetadata {
 }
 
 // Model metadata that is specific to text classification.
-message TextClassificationModelMetadata {}
+message TextClassificationModelMetadata {
+
+}
+
+// Dataset metadata that is specific to text extraction
+message TextExtractionDatasetMetadata {
+
+}
+
+// Model metadata that is specific to text extraction.
+message TextExtractionModelMetadata {
+
+}
+
+// Dataset metadata for text sentiment.
+message TextSentimentDatasetMetadata {
+  // Required.
+  // A sentiment is expressed as an integer ordinal, where higher value
+  // means a more positive sentiment. The range of sentiments that will be used
+  // is between 0 and sentiment_max (inclusive on both ends), and all the values
+  // in the range must be represented in the dataset before a model can be
+  // created.
+  // sentiment_max value must be between 1 and 10 (inclusive).
+  int32 sentiment_max = 1;
+}
+
+// Model metadata that is specific to text classification.
+message TextSentimentModelMetadata {
+
+}

--- a/protos/google/cloud/automl/v1beta1/text_extraction.proto
+++ b/protos/google/cloud/automl/v1beta1/text_extraction.proto
@@ -1,0 +1,64 @@
+// Copyright 2018 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package google.cloud.automl.v1beta1;
+
+import "google/api/annotations.proto";
+import "google/cloud/automl/v1beta1/text_segment.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/cloud/automl/v1beta1;automl";
+option java_multiple_files = true;
+option java_package = "com.google.cloud.automl.v1beta1";
+option php_namespace = "Google\\Cloud\\AutoMl\\V1beta1";
+
+
+// Annotation for identifying spans of text.
+message TextExtractionAnnotation {
+  // Output only. A confidence estimate between 0.0 and 1.0. A higher value
+  // means greater confidence in correctness of the annotation.
+  float score = 1;
+
+  // Required. The part of the original text to which this annotation pertains.
+  TextSegment text_segment = 3;
+}
+
+// Model evaluation metrics for text extraction problems.
+message TextExtractionEvaluationMetrics {
+  // Metrics for a single confidence threshold.
+  message ConfidenceMetricsEntry {
+    // Output only. The confidence threshold value used to compute the metrics.
+    // Only annotations with score of at least this threshold are considered to
+    // be ones the model would return.
+    float confidence_threshold = 1;
+
+    // Output only. Recall under the given confidence threshold.
+    float recall = 3;
+
+    // Output only. Precision under the given confidence threshold.
+    float precision = 4;
+
+    // Output only. The harmonic mean of recall and precision.
+    float f1_score = 5;
+  }
+
+  // Output only. The Area under precision recall curve metric.
+  float au_prc = 1;
+
+  // Output only. Metrics that have confidence thresholds.
+  // Precision-recall curve can be derived from it.
+  repeated ConfidenceMetricsEntry confidence_metrics_entries = 2;
+}

--- a/protos/google/cloud/automl/v1beta1/text_segment.proto
+++ b/protos/google/cloud/automl/v1beta1/text_segment.proto
@@ -1,0 +1,43 @@
+// Copyright 2018 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package google.cloud.automl.v1beta1;
+
+import "google/api/annotations.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/cloud/automl/v1beta1;automl";
+option java_multiple_files = true;
+option java_outer_classname = "TextSegmentProto";
+option java_package = "com.google.cloud.automl.v1beta1";
+option php_namespace = "Google\\Cloud\\AutoMl\\V1beta1";
+
+
+// A contiguous part of a text (string), assuming it has an UTF-8 NFC encoding.
+// .
+message TextSegment {
+  // Output only. The content of the TextSegment.
+  string content = 3;
+
+  // Required. Zero-based character index of the first character of the text
+  // segment (counting characters from the beginning of the text).
+  int64 start_offset = 1;
+
+  // Required. Zero-based character index of the first character past the end of
+  // the text segment (counting character from the beginning of the text).
+  // The character at the end_offset is NOT included in the text segment.
+  int64 end_offset = 2;
+}

--- a/protos/google/cloud/automl/v1beta1/text_sentiment.proto
+++ b/protos/google/cloud/automl/v1beta1/text_sentiment.proto
@@ -1,0 +1,84 @@
+// Copyright 2018 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package google.cloud.automl.v1beta1;
+
+import "google/api/annotations.proto";
+import "google/cloud/automl/v1beta1/classification.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/cloud/automl/v1beta1;automl";
+option java_outer_classname = "TextSentimentProto";
+option java_package = "com.google.cloud.automl.v1beta1";
+option php_namespace = "Google\\Cloud\\AutoMl\\V1beta1";
+
+
+// Contains annotation details specific to text sentiment.
+message TextSentimentAnnotation {
+  // Output only. The sentiment with the semantic, as given to the
+  // [AutoMl.ImportData][google.cloud.automl.v1beta1.AutoMl.ImportData] when populating the dataset from which the model used
+  // for the prediction had been trained.
+  // The sentiment values are between 0 and
+  // Dataset.text_sentiment_dataset_metadata.sentiment_max (inclusive),
+  // with higher value meaning more positive sentiment. They are completely
+  // relative, i.e. 0 means least positive sentiment and sentiment_max means
+  // the most positive from the sentiments present in the train data. Therefore
+  //  e.g. if train data had only negative sentiment, then sentiment_max, would
+  // be still negative (although least negative).
+  // The sentiment shouldn't be confused with "score" or "magnitude"
+  // from the previous Natural Language Sentiment Analysis API.
+  int32 sentiment = 1;
+}
+
+// Model evaluation metrics for text sentiment problems.
+message TextSentimentEvaluationMetrics {
+  // Output only. Precision.
+  float precision = 1;
+
+  // Output only. Recall.
+  float recall = 2;
+
+  // Output only. The harmonic mean of recall and precision.
+  float f1_score = 3;
+
+  // Output only. Mean absolute error. Only set for the overall model
+  // evaluation, not for evaluation of a single annotation spec.
+  float mean_absolute_error = 4;
+
+  // Output only. Mean squared error. Only set for the overall model
+  // evaluation, not for evaluation of a single annotation spec.
+  float mean_squared_error = 5;
+
+  // Output only. Linear weighted kappa. Only set for the overall model
+  // evaluation, not for evaluation of a single annotation spec.
+  float linear_kappa = 6;
+
+  // Output only. Quadratic weighted kappa. Only set for the overall model
+  // evaluation, not for evaluation of a single annotation spec.
+  float quadratic_kappa = 7;
+
+  // Output only. Confusion matrix of the evaluation.
+  // Only set for the overall model evaluation, not for evaluation of a single
+  // annotation spec.
+  ClassificationEvaluationMetrics.ConfusionMatrix confusion_matrix = 8;
+
+  // Output only. The annotation spec ids used for this evaluation.
+  // Deprecated, remove after Boq Migration and use then
+  // TextSentimentModelMetadata.annotation_spec_count for count, and list
+  // all model evaluations to see the exact annotation_spec_ids that were
+  // used.
+  repeated string annotation_spec_id = 9;
+}

--- a/protos/google/cloud/automl/v1beta1/translation.proto
+++ b/protos/google/cloud/automl/v1beta1/translation.proto
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
 syntax = "proto3";
 
@@ -24,6 +25,7 @@ option java_multiple_files = true;
 option java_outer_classname = "TranslationProto";
 option java_package = "com.google.cloud.automl.v1beta1";
 option php_namespace = "Google\\Cloud\\AutoMl\\V1beta1";
+
 
 // Dataset metadata that is specific to translation.
 message TranslationDatasetMetadata {

--- a/protos/google/cloud/automl/v1beta1/video.proto
+++ b/protos/google/cloud/automl/v1beta1/video.proto
@@ -1,0 +1,39 @@
+// Copyright 2018 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package google.cloud.automl.v1beta1;
+
+import "google/api/annotations.proto";
+import "google/cloud/automl/v1beta1/classification.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/cloud/automl/v1beta1;automl";
+option java_multiple_files = true;
+option java_outer_classname = "VideoProto";
+option java_package = "com.google.cloud.automl.v1beta1";
+option php_namespace = "Google\\Cloud\\AutoMl\\V1beta1";
+
+
+// Dataset metadata specific to video classification.
+// All Video Classification datasets are treated as multi label.
+message VideoClassificationDatasetMetadata {
+
+}
+
+// Model metadata specific to video classification.
+message VideoClassificationModelMetadata {
+
+}

--- a/src/v1beta1/auto_ml_client_config.json
+++ b/src/v1beta1/auto_ml_client_config.json
@@ -25,13 +25,18 @@
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
+        "UpdateDataset": {
+          "timeout_millis": 5000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
         "GetDataset": {
           "timeout_millis": 5000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "ListDatasets": {
-          "timeout_millis": 5000,
+          "timeout_millis": 50000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
@@ -41,7 +46,7 @@
           "retry_params_name": "default"
         },
         "ImportData": {
-          "timeout_millis": 5000,
+          "timeout_millis": 20000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
@@ -51,7 +56,7 @@
           "retry_params_name": "default"
         },
         "CreateModel": {
-          "timeout_millis": 5000,
+          "timeout_millis": 20000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
@@ -61,7 +66,7 @@
           "retry_params_name": "default"
         },
         "ListModels": {
-          "timeout_millis": 5000,
+          "timeout_millis": 50000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
@@ -85,7 +90,52 @@
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
+        "ExportModel": {
+          "timeout_millis": 5000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "ExportEvaluatedExamples": {
+          "timeout_millis": 5000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
         "ListModelEvaluations": {
+          "timeout_millis": 50000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "GetAnnotationSpec": {
+          "timeout_millis": 5000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "GetTableSpec": {
+          "timeout_millis": 5000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "ListTableSpecs": {
+          "timeout_millis": 5000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "UpdateTableSpec": {
+          "timeout_millis": 5000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "GetColumnSpec": {
+          "timeout_millis": 5000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "ListColumnSpecs": {
+          "timeout_millis": 5000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "UpdateColumnSpec": {
           "timeout_millis": 5000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"

--- a/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_annotation_payload.js
+++ b/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_annotation_payload.js
@@ -28,18 +28,43 @@
  *
  *   This object should have the same structure as [ClassificationAnnotation]{@link google.cloud.automl.v1beta1.ClassificationAnnotation}
  *
+ * @property {Object} imageObjectDetection
+ *   Annotation details for image object detection.
+ *
+ *   This object should have the same structure as [ImageObjectDetectionAnnotation]{@link google.cloud.automl.v1beta1.ImageObjectDetectionAnnotation}
+ *
+ * @property {Object} videoClassification
+ *   Annotation details for video classification.
+ *   Returned for Video Classification predictions.
+ *
+ *   This object should have the same structure as [VideoClassificationAnnotation]{@link google.cloud.automl.v1beta1.VideoClassificationAnnotation}
+ *
+ * @property {Object} textExtraction
+ *   Annotation details for text extraction.
+ *
+ *   This object should have the same structure as [TextExtractionAnnotation]{@link google.cloud.automl.v1beta1.TextExtractionAnnotation}
+ *
+ * @property {Object} textSentiment
+ *   Annotation details for text sentiment.
+ *
+ *   This object should have the same structure as [TextSentimentAnnotation]{@link google.cloud.automl.v1beta1.TextSentimentAnnotation}
+ *
+ * @property {Object} tables
+ *   Annotation details for Tables.
+ *
+ *   This object should have the same structure as [TablesAnnotation]{@link google.cloud.automl.v1beta1.TablesAnnotation}
+ *
  * @property {string} annotationSpecId
  *   Output only . The resource ID of the annotation spec that
  *   this annotation pertains to. The annotation spec comes from either an
  *   ancestor dataset, or the dataset that was used to train the model in use.
  *
  * @property {string} displayName
- *   Output only. The value of
- *   AnnotationSpec.display_name
- *   when the model was trained. Because this field returns a value at model
- *   training time, for different models trained using the same dataset, the
- *   returned value could be different as model owner could update the
- *   display_name between any two model training.
+ *   Output only. The value of AnnotationSpec.display_name when the model
+ *   was trained. Because this field returns a value at model training time,
+ *   for different models trained using the same dataset, the returned value
+ *   could be different as model owner could update the display_name between
+ *   any two model training.
  *
  * @typedef AnnotationPayload
  * @memberof google.cloud.automl.v1beta1

--- a/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_column_spec.js
+++ b/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_column_spec.js
@@ -1,0 +1,90 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
+
+/**
+ * A representation of a column in a relational table. When listing them, column specs are returned in the same order in which they were
+ * given on import .
+ * Used by:
+ *   *   Tables
+ *
+ * @property {string} name
+ *   Output only. The resource name of the column specs.
+ *   Form:
+ *
+ *   `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/tableSpecs/{table_spec_id}/columnSpecs/{column_spec_id}`
+ *
+ * @property {Object} dataType
+ *   The data type of elements stored in the column.
+ *
+ *   This object should have the same structure as [DataType]{@link google.cloud.automl.v1beta1.DataType}
+ *
+ * @property {string} displayName
+ *   Output only. The name of the column to show in the interface. The name can
+ *   be up to 100 characters long and can consist only of ASCII Latin letters
+ *   A-Z and a-z, ASCII digits 0-9, underscores(_), and forward slashes(/), and
+ *   must start with a letter or a digit.
+ *
+ * @property {Object} dataStats
+ *   Output only. Stats of the series of values in the column.
+ *   This field may be stale, see the ancestor's
+ *   Dataset.tables_dataset_metadata.stats_update_time field
+ *   for the timestamp at which these stats were last updated.
+ *
+ *   This object should have the same structure as [DataStats]{@link google.cloud.automl.v1beta1.DataStats}
+ *
+ * @property {Object[]} topCorrelatedColumns
+ *   Output only. Top 10 most correlated with this column columns of the table,
+ *   ordered by
+ *   cramers_v metric.
+ *   This field may be stale, see the ancestor's
+ *   Dataset.tables_dataset_metadata.stats_update_time field
+ *   for the timestamp at which these stats were last updated.
+ *
+ *   This object should have the same structure as [CorrelatedColumn]{@link google.cloud.automl.v1beta1.CorrelatedColumn}
+ *
+ * @property {string} etag
+ *   Used to perform consistent read-modify-write updates. If not set, a blind
+ *   "overwrite" update happens.
+ *
+ * @typedef ColumnSpec
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.ColumnSpec definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/column_spec.proto}
+ */
+const ColumnSpec = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+
+  /**
+   * Identifies the table's column, and its correlation with the column this
+   * ColumnSpec describes.
+   *
+   * @property {string} columnSpecId
+   *   The column_spec_id of the correlated column, which belongs to the same
+   *   table as the in-context column.
+   *
+   * @property {Object} correlationStats
+   *   Correlation between this and the in-context column.
+   *
+   *   This object should have the same structure as [CorrelationStats]{@link google.cloud.automl.v1beta1.CorrelationStats}
+   *
+   * @typedef CorrelatedColumn
+   * @memberof google.cloud.automl.v1beta1
+   * @see [google.cloud.automl.v1beta1.ColumnSpec.CorrelatedColumn definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/column_spec.proto}
+   */
+  CorrelatedColumn: {
+    // This is for documentation. Actual contents will be loaded by gRPC.
+  }
+};

--- a/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_data_items.js
+++ b/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_data_items.js
@@ -17,6 +17,7 @@
 
 /**
  * A representation of an image.
+ * Only images up to 30MB in size are supported.
  *
  * @property {string} imageBytes
  *   Image content represented as a stream of bytes.
@@ -47,10 +48,9 @@ const Image = {
  *   characters long.
  *
  * @property {string} mimeType
- *   The format of the source text. For example, "text/html" or
- *   "text/plain". If left blank the format is automatically determined from
- *   the type of the uploaded content. The default is "text/html". Up to 25000
- *   characters long.
+ *   The format of the source text. Currently the only two allowed values are
+ *   "text/html" and "text/plain". If left blank the format is automatically
+ *   determined from the type of the uploaded content.
  *
  * @property {string} contentUri
  *   Output only. HTTP URI where you can download the content.
@@ -64,10 +64,55 @@ const TextSnippet = {
 };
 
 /**
+ * A structured text document e.g. a PDF.
+ *
+ * @property {Object} inputConfig
+ *   An input config specifying the content of the document.
+ *
+ *   This object should have the same structure as [DocumentInputConfig]{@link google.cloud.automl.v1beta1.DocumentInputConfig}
+ *
+ * @typedef Document
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.Document definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/data_items.proto}
+ */
+const Document = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * A representation of a row in a relational table.
+ *
+ * @property {string[]} columnSpecIds
+ *   The resource IDs of the column specs describing the columns of the row.
+ *   If set must contain, but possibly in a different order, all input feature
+ *
+ *   column_spec_ids
+ *   of the Model this row is being passed to.
+ *   Note: The below `values` field must match order of this field, if this
+ *   field is set.
+ *
+ * @property {Object[]} values
+ *   Required. The values of the row cells, given in the same order as the
+ *   column_spec_ids, or, if not set, then in the same order as input feature
+ *
+ *   column_specs
+ *   of the Model this row is being passed to.
+ *
+ *   This object should have the same structure as [Value]{@link google.protobuf.Value}
+ *
+ * @typedef Row
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.Row definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/data_items.proto}
+ */
+const Row = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
  * Example data used for training or prediction.
  *
  * @property {Object} image
- *   An example image.
+ *   Example image.
  *
  *   This object should have the same structure as [Image]{@link google.cloud.automl.v1beta1.Image}
  *
@@ -75,6 +120,16 @@ const TextSnippet = {
  *   Example text.
  *
  *   This object should have the same structure as [TextSnippet]{@link google.cloud.automl.v1beta1.TextSnippet}
+ *
+ * @property {Object} document
+ *   Example document.
+ *
+ *   This object should have the same structure as [Document]{@link google.cloud.automl.v1beta1.Document}
+ *
+ * @property {Object} row
+ *   Example relational table row.
+ *
+ *   This object should have the same structure as [Row]{@link google.cloud.automl.v1beta1.Row}
  *
  * @typedef ExamplePayload
  * @memberof google.cloud.automl.v1beta1

--- a/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_data_stats.js
+++ b/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_data_stats.js
@@ -1,0 +1,267 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
+
+/**
+ * The data statistics of a series of values that share the same DataType.
+ *
+ * @property {Object} float64Stats
+ *   The statistics for FLOAT64 DataType.
+ *
+ *   This object should have the same structure as [Float64Stats]{@link google.cloud.automl.v1beta1.Float64Stats}
+ *
+ * @property {Object} stringStats
+ *   The statistics for STRING DataType.
+ *
+ *   This object should have the same structure as [StringStats]{@link google.cloud.automl.v1beta1.StringStats}
+ *
+ * @property {Object} timestampStats
+ *   The statistics for TIMESTAMP DataType.
+ *
+ *   This object should have the same structure as [TimestampStats]{@link google.cloud.automl.v1beta1.TimestampStats}
+ *
+ * @property {Object} arrayStats
+ *   The statistics for ARRAY DataType.
+ *
+ *   This object should have the same structure as [ArrayStats]{@link google.cloud.automl.v1beta1.ArrayStats}
+ *
+ * @property {Object} structStats
+ *   The statistics for STRUCT DataType.
+ *
+ *   This object should have the same structure as [StructStats]{@link google.cloud.automl.v1beta1.StructStats}
+ *
+ * @property {Object} categoryStats
+ *   The statistics for CATEGORY DataType.
+ *
+ *   This object should have the same structure as [CategoryStats]{@link google.cloud.automl.v1beta1.CategoryStats}
+ *
+ * @property {number} distinctValueCount
+ *   The number of distinct values.
+ *
+ * @property {number} nullValueCount
+ *   The number of values that are null.
+ *
+ * @typedef DataStats
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.DataStats definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/data_stats.proto}
+ */
+const DataStats = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * The data statistics of a series of FLOAT64 values.
+ *
+ * @property {number} mean
+ *   The mean of the series.
+ *
+ * @property {number} standardDeviation
+ *   The standard deviation of the series.
+ *
+ * @property {number[]} quantiles
+ *   Ordered from 0 to k k-quantile values of the data series of n values.
+ *   The value at index i is, approximately, the i*n/k-th smallest value in the
+ *   series; for i = 0 and i = k these are, respectively, the min and max
+ *   values.
+ *
+ * @property {Object[]} histogramBuckets
+ *   Histogram buckets of the data series. Sorted by the min value of the
+ *   bucket, ascendingly, and the number of the buckets is dynamically
+ *   generated. The buckets are non-overlapping and completely cover whole
+ *   FLOAT64 range with min of first bucket being `"-Infinity"`, and max of
+ *   the last one being `"Infinity"`.
+ *
+ *   This object should have the same structure as [HistogramBucket]{@link google.cloud.automl.v1beta1.HistogramBucket}
+ *
+ * @typedef Float64Stats
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.Float64Stats definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/data_stats.proto}
+ */
+const Float64Stats = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+
+  /**
+   * A bucket of a histogram.
+   *
+   * @property {number} min
+   *   The minimum value of the bucket, inclusive.
+   *
+   * @property {number} max
+   *   The maximum value of the bucket, exclusive unless max = `"Infinity"`, in
+   *   which case it's inclusive.
+   *
+   * @property {number} count
+   *   The number of data values that are in the bucket, i.e. are between
+   *   min and max values.
+   *
+   * @typedef HistogramBucket
+   * @memberof google.cloud.automl.v1beta1
+   * @see [google.cloud.automl.v1beta1.Float64Stats.HistogramBucket definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/data_stats.proto}
+   */
+  HistogramBucket: {
+    // This is for documentation. Actual contents will be loaded by gRPC.
+  }
+};
+
+/**
+ * The data statistics of a series of STRING values.
+ *
+ * @property {Object[]} topUnigramStats
+ *   The statistics of the top 20 unigrams, ordered by
+ *   count.
+ *
+ *   This object should have the same structure as [UnigramStats]{@link google.cloud.automl.v1beta1.UnigramStats}
+ *
+ * @typedef StringStats
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.StringStats definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/data_stats.proto}
+ */
+const StringStats = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+
+  /**
+   * The statistics of a unigram.
+   *
+   * @property {string} value
+   *   The unigram.
+   *
+   * @property {number} count
+   *   The number of occurrences of this unigram in the series.
+   *
+   * @typedef UnigramStats
+   * @memberof google.cloud.automl.v1beta1
+   * @see [google.cloud.automl.v1beta1.StringStats.UnigramStats definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/data_stats.proto}
+   */
+  UnigramStats: {
+    // This is for documentation. Actual contents will be loaded by gRPC.
+  }
+};
+
+/**
+ * The data statistics of a series of TIMESTAMP values.
+ *
+ * @property {Object.<string, Object>} granularStats
+ *   The string key is the pre-defined granularity. Currently supported:
+ *   hour_of_day, day_of_week, month_of_year.
+ *   Granularities finer that the granularity of timestamp data are not
+ *   populated (e.g. if timestamps are at day granularity, then hour_of_day
+ *   is not populated).
+ *
+ * @typedef TimestampStats
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.TimestampStats definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/data_stats.proto}
+ */
+const TimestampStats = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+
+  /**
+   * Stats split by a defined in context granularity.
+   *
+   * @property {Object.<number, number>} buckets
+   *   A map from granularity key to example count for that key.
+   *   E.g. for hour_of_day `13` means 1pm, or for month_of_year `5` means May).
+   *
+   * @typedef GranularStats
+   * @memberof google.cloud.automl.v1beta1
+   * @see [google.cloud.automl.v1beta1.TimestampStats.GranularStats definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/data_stats.proto}
+   */
+  GranularStats: {
+    // This is for documentation. Actual contents will be loaded by gRPC.
+  }
+};
+
+/**
+ * The data statistics of a series of ARRAY values.
+ *
+ * @property {Object} memberStats
+ *   Stats of all the values of all arrays, as if they were a single long
+ *   series of data. The type depends on the element type of the array.
+ *
+ *   This object should have the same structure as [DataStats]{@link google.cloud.automl.v1beta1.DataStats}
+ *
+ * @typedef ArrayStats
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.ArrayStats definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/data_stats.proto}
+ */
+const ArrayStats = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * The data statistics of a series of STRUCT values.
+ *
+ * @property {Object.<string, Object>} fieldStats
+ *   Map from a field name of the struct to data stats aggregated over series
+ *   of all data in that field across all the structs.
+ *
+ * @typedef StructStats
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.StructStats definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/data_stats.proto}
+ */
+const StructStats = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * The data statistics of a series of CATEGORY values.
+ *
+ * @property {Object[]} topCategoryStats
+ *   The statistics of the top 20 CATEGORY values, ordered by
+ *
+ *   count.
+ *
+ *   This object should have the same structure as [SingleCategoryStats]{@link google.cloud.automl.v1beta1.SingleCategoryStats}
+ *
+ * @typedef CategoryStats
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.CategoryStats definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/data_stats.proto}
+ */
+const CategoryStats = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+
+  /**
+   * The statistics of a single CATEGORY value.
+   *
+   * @property {string} value
+   *   The CATEGORY value.
+   *
+   * @property {number} count
+   *   The number of occurrences of this value in the series.
+   *
+   * @typedef SingleCategoryStats
+   * @memberof google.cloud.automl.v1beta1
+   * @see [google.cloud.automl.v1beta1.CategoryStats.SingleCategoryStats definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/data_stats.proto}
+   */
+  SingleCategoryStats: {
+    // This is for documentation. Actual contents will be loaded by gRPC.
+  }
+};
+
+/**
+ * A correlation statistics between two series of DataType values. The series
+ * may have differing DataType-s, but within a single series the DataType must
+ * be the same.
+ *
+ * @property {number} cramersV
+ *   The correlation value using the Cramer's V measure.
+ *
+ * @typedef CorrelationStats
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.CorrelationStats definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/data_stats.proto}
+ */
+const CorrelationStats = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};

--- a/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_data_types.js
+++ b/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_data_types.js
@@ -1,0 +1,142 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
+
+/**
+ * Indicated the type of data that can be stored in a structured data entity
+ * (e.g. a table).
+ *
+ * @property {Object} listElementType
+ *   If type_code == ARRAY,
+ *   then `list_element_type` is the type of the elements.
+ *
+ *   This object should have the same structure as [DataType]{@link google.cloud.automl.v1beta1.DataType}
+ *
+ * @property {Object} structType
+ *   If type_code == STRUCT, then `struct_type`
+ *   provides type information for the struct's fields.
+ *
+ *   This object should have the same structure as [StructType]{@link google.cloud.automl.v1beta1.StructType}
+ *
+ * @property {string} timeFormat
+ *   If type_code == TIMESTAMP
+ *   then `time_format` provides the format in which that time field is
+ *   expressed. The time_format must either be one of:
+ *   * `UNIX_SECONDS`
+ *   * `UNIX_MILLISECONDS`
+ *   * `UNIX_MICROSECONDS`
+ *   * `UNIX_NANOSECONDS`
+ *   (for respectively number of seconds, milliseconds, microseconds and
+ *   nanoseconds since start of the Unix epoch);
+ *   or be written in `strftime` syntax. If time_format is not set, then the
+ *   default format as described on the type_code is used.
+ *
+ * @property {number} typeCode
+ *   Required. The TypeCode for this type.
+ *
+ *   The number should be among the values of [TypeCode]{@link google.cloud.automl.v1beta1.TypeCode}
+ *
+ * @property {boolean} nullable
+ *   If true, this DataType can also be `null`.
+ *
+ * @typedef DataType
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.DataType definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/data_types.proto}
+ */
+const DataType = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * `StructType` defines the DataType-s of a STRUCT type.
+ *
+ * @property {Object.<string, Object>} fields
+ *   Unordered map of struct field names to their data types.
+ *   Fields cannot be added or removed via Update. Their names and
+ *   data types are still mutable.
+ *
+ * @typedef StructType
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.StructType definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/data_types.proto}
+ */
+const StructType = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * `TypeCode` is used as a part of
+ * DataType.
+ *
+ * Each legal value of a DataType can be encoded to or decoded from a JSON
+ * value, using the encodings listed below, and definitions of which can be
+ * found at
+ *
+ * https:
+ * //developers.google.com/protocol-buffers
+ * // /docs/reference/google.protobuf#value.
+ *
+ * @enum {number}
+ * @memberof google.cloud.automl.v1beta1
+ */
+const TypeCode = {
+
+  /**
+   * Not specified. Should not be used.
+   */
+  TYPE_CODE_UNSPECIFIED: 0,
+
+  /**
+   * Encoded as `number`, or the strings `"NaN"`, `"Infinity"`, or
+   * `"-Infinity"`.
+   */
+  FLOAT64: 3,
+
+  /**
+   * Must be between 0AD and 9999AD. Encoded as `string` according to
+   * time_format, or, if
+   * that format is not set, then in RFC 3339 `date-time` format, where
+   * `time-offset` = `"Z"` (e.g. 1985-04-12T23:20:50.52Z).
+   */
+  TIMESTAMP: 4,
+
+  /**
+   * Encoded as `string`.
+   */
+  STRING: 6,
+
+  /**
+   * Encoded as `list`, where the list elements are represented according to
+   *
+   * list_element_type.
+   */
+  ARRAY: 8,
+
+  /**
+   * Encoded as `struct`, where field values are represented according to
+   * struct_type.
+   */
+  STRUCT: 9,
+
+  /**
+   * Values of this type are not further understood by AutoML,
+   * e.g. AutoML is unable to tell the order of values (as it could with
+   * FLOAT64), or is unable to say if one value contains another (as it
+   * could with STRING).
+   * Encoded as `string` (bytes should be base64-encoded, as described in RFC
+   * 4648, section 4).
+   */
+  CATEGORY: 10
+};

--- a/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_dataset.js
+++ b/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_dataset.js
@@ -34,15 +34,44 @@
  *
  *   This object should have the same structure as [TextClassificationDatasetMetadata]{@link google.cloud.automl.v1beta1.TextClassificationDatasetMetadata}
  *
+ * @property {Object} imageObjectDetectionDatasetMetadata
+ *   Metadata for a dataset used for image object detection.
+ *
+ *   This object should have the same structure as [ImageObjectDetectionDatasetMetadata]{@link google.cloud.automl.v1beta1.ImageObjectDetectionDatasetMetadata}
+ *
+ * @property {Object} videoClassificationDatasetMetadata
+ *   Metadata for a dataset used for video classification.
+ *
+ *   This object should have the same structure as [VideoClassificationDatasetMetadata]{@link google.cloud.automl.v1beta1.VideoClassificationDatasetMetadata}
+ *
+ * @property {Object} textExtractionDatasetMetadata
+ *   Metadata for a dataset used for text extraction.
+ *
+ *   This object should have the same structure as [TextExtractionDatasetMetadata]{@link google.cloud.automl.v1beta1.TextExtractionDatasetMetadata}
+ *
+ * @property {Object} textSentimentDatasetMetadata
+ *   Metadata for a dataset used for text sentiment.
+ *
+ *   This object should have the same structure as [TextSentimentDatasetMetadata]{@link google.cloud.automl.v1beta1.TextSentimentDatasetMetadata}
+ *
+ * @property {Object} tablesDatasetMetadata
+ *   Metadata for a dataset used for Tables.
+ *
+ *   This object should have the same structure as [TablesDatasetMetadata]{@link google.cloud.automl.v1beta1.TablesDatasetMetadata}
+ *
  * @property {string} name
  *   Output only. The resource name of the dataset.
  *   Form: `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}`
  *
  * @property {string} displayName
  *   Required. The name of the dataset to show in the interface. The name can be
- *   up to 32 characters
- *   long and can consist only of ASCII Latin letters A-Z and a-z, underscores
+ *   up to 32 characters long and can consist only of ASCII Latin letters A-Z
+ *   and a-z, underscores
  *   (_), and ASCII digits 0-9.
+ *
+ * @property {string} description
+ *   User-provided description of the dataset. The description can be up to
+ *   25000 characters long.
  *
  * @property {number} exampleCount
  *   Output only. The number of examples in the dataset.
@@ -52,10 +81,42 @@
  *
  *   This object should have the same structure as [Timestamp]{@link google.protobuf.Timestamp}
  *
+ * @property {string} etag
+ *   Used to perform consistent read-modify-write updates. If not set, a blind
+ *   "overwrite" update happens.
+ *
  * @typedef Dataset
  * @memberof google.cloud.automl.v1beta1
  * @see [google.cloud.automl.v1beta1.Dataset definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/dataset.proto}
  */
 const Dataset = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * A definition of an annotation.
+ *
+ * @property {string} name
+ *   Output only. Resource name of the annotation spec.
+ *   Form:
+ *
+ *   'projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/annotationSpecs/{annotation_spec_id}'
+ *
+ * @property {string} displayName
+ *   Required.
+ *   The name of the annotation spec to show in the interface. The name can be
+ *   up to 32 characters long and can consist only of ASCII Latin letters A-Z
+ *   and a-z, underscores
+ *   (_), and ASCII digits 0-9.
+ *
+ * @property {number} exampleCount
+ *   Output only. The number of examples in the parent dataset
+ *   labeled by the annotation spec.
+ *
+ * @typedef AnnotationSpec
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.AnnotationSpec definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/dataset.proto}
+ */
+const AnnotationSpec = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };

--- a/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_detection.js
+++ b/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_detection.js
@@ -1,0 +1,115 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
+
+/**
+ * Annotation details for image object detection.
+ *
+ * @property {Object} boundingBox
+ *   Output only.
+ *   The rectangle representing the object location.
+ *
+ *   This object should have the same structure as [BoundingPoly]{@link google.cloud.automl.v1beta1.BoundingPoly}
+ *
+ * @property {number} score
+ *   Output only.
+ *   The confidence that this annotation is positive for the parent example,
+ *   value in [0, 1], higher means higher positivity confidence.
+ *
+ * @typedef ImageObjectDetectionAnnotation
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.ImageObjectDetectionAnnotation definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/detection.proto}
+ */
+const ImageObjectDetectionAnnotation = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Bounding box matching model metrics for a single intersection-over-union
+ * threshold and multiple label match confidence thresholds.
+ *
+ * @property {number} iouThreshold
+ *   Output only. The intersection-over-union threshold value used to compute
+ *   this metrics entry.
+ *
+ * @property {number} meanAveragePrecision
+ *   Output only. The mean average precision, most often close to au_prc.
+ *
+ * @property {Object[]} confidenceMetricsEntries
+ *   Output only. Metrics for each label-match confidence_threshold from
+ *   0.05,0.10,...,0.95,0.96,0.97,0.98,0.99. Precision-recall curve is
+ *   derived from them.
+ *
+ *   This object should have the same structure as [ConfidenceMetricsEntry]{@link google.cloud.automl.v1beta1.ConfidenceMetricsEntry}
+ *
+ * @typedef BoundingBoxMetricsEntry
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.BoundingBoxMetricsEntry definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/detection.proto}
+ */
+const BoundingBoxMetricsEntry = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+
+  /**
+   * Metrics for a single confidence threshold.
+   *
+   * @property {number} confidenceThreshold
+   *   Output only. The confidence threshold value used to compute the metrics.
+   *
+   * @property {number} recall
+   *   Output only. Recall under the given confidence threshold.
+   *
+   * @property {number} precision
+   *   Output only. Precision under the given confidence threshold.
+   *
+   * @property {number} f1Score
+   *   Output only. The harmonic mean of recall and precision.
+   *
+   * @typedef ConfidenceMetricsEntry
+   * @memberof google.cloud.automl.v1beta1
+   * @see [google.cloud.automl.v1beta1.BoundingBoxMetricsEntry.ConfidenceMetricsEntry definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/detection.proto}
+   */
+  ConfidenceMetricsEntry: {
+    // This is for documentation. Actual contents will be loaded by gRPC.
+  }
+};
+
+/**
+ * Model evaluation metrics for image object detection problems.
+ * Evaluates prediction quality of labeled bounding boxes.
+ *
+ * @property {number} evaluatedBoundingBoxCount
+ *   Output only. The total number of bounding boxes (i.e. summed over all
+ *   images) the ground truth used to create this evaluation had.
+ *
+ * @property {Object[]} boundingBoxMetricsEntries
+ *   Output only. The bounding boxes match metrics for each
+ *   Intersection-over-union threshold 0.05,0.10,...,0.95,0.96,0.97,0.98,0.99
+ *   and each label confidence threshold 0.05,0.10,...,0.95,0.96,0.97,0.98,0.99
+ *   pair.
+ *
+ *   This object should have the same structure as [BoundingBoxMetricsEntry]{@link google.cloud.automl.v1beta1.BoundingBoxMetricsEntry}
+ *
+ * @property {number} boundingBoxMeanAveragePrecision
+ *   Output only. The single metric for bounding boxes evaluation:
+ *   the mean_average_precision averaged over all bounding_box_metrics_entries.
+ *
+ * @typedef ImageObjectDetectionEvaluationMetrics
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.ImageObjectDetectionEvaluationMetrics definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/detection.proto}
+ */
+const ImageObjectDetectionEvaluationMetrics = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};

--- a/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_geometry.js
+++ b/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_geometry.js
@@ -1,0 +1,55 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
+
+/**
+ * A vertex represents a 2D point in the image.
+ * The normalized vertex coordinates are between 0 to 1 fractions relative to
+ * the original plane (image, video). E.g. if the plane (e.g. whole image) would
+ * have size 10 x 20 then a point with normalized coordinates (0.1, 0.3) would
+ * be at the position (1, 6) on that plane.
+ *
+ * @property {number} x
+ *   Required. Horizontal coordinate.
+ *
+ * @property {number} y
+ *   Required. Vertical coordinate.
+ *
+ * @typedef NormalizedVertex
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.NormalizedVertex definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/geometry.proto}
+ */
+const NormalizedVertex = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * A bounding polygon of a detected object on a plane.
+ * On output both vertices and normalized_vertices are provided.
+ * The polygon is formed by connecting vertices in the order they are listed.
+ *
+ * @property {Object[]} normalizedVertices
+ *   Output only . The bounding polygon normalized vertices.
+ *
+ *   This object should have the same structure as [NormalizedVertex]{@link google.cloud.automl.v1beta1.NormalizedVertex}
+ *
+ * @typedef BoundingPoly
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.BoundingPoly definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/geometry.proto}
+ */
+const BoundingPoly = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};

--- a/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_image.js
+++ b/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_image.js
@@ -19,8 +19,7 @@
  * Dataset metadata that is specific to image classification.
  *
  * @property {number} classificationType
- *   Required.
- *   Type of the classification problem.
+ *   Required. Type of the classification problem.
  *
  *   The number should be among the values of [ClassificationType]{@link google.cloud.automl.v1beta1.ClassificationType}
  *
@@ -33,31 +32,126 @@ const ImageClassificationDatasetMetadata = {
 };
 
 /**
+ * Dataset metadata specific to image object detection.
+ * @typedef ImageObjectDetectionDatasetMetadata
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.ImageObjectDetectionDatasetMetadata definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/image.proto}
+ */
+const ImageObjectDetectionDatasetMetadata = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
  * Model metadata for image classification.
  *
  * @property {string} baseModelId
  *   Optional. The ID of the `base` model. If it is specified, the new model
  *   will be created based on the `base` model. Otherwise, the new model will be
- *   created from scratch. The `base` model is expected to be in the same
- *   `project` and `location` as the new model to create.
+ *   created from scratch. The `base` model must be in the same
+ *   `project` and `location` as the new model to create, and have the same
+ *   `model_type`.
  *
  * @property {number} trainBudget
- *   Required. The train budget of creating this model. The actual
- *   `train_cost` will be equal or less than this value.
+ *   Required. The train budget of creating this model, expressed in hours. The
+ *   actual `train_cost` will be equal or less than this value.
  *
  * @property {number} trainCost
- *   Output only. The actual train cost of creating this model. If this
- *   model is created from a `base` model, the train cost used to create the
- *   `base` model are not included.
+ *   Output only. The actual train cost of creating this model, expressed in
+ *   hours. If this model is created from a `base` model, the train cost used
+ *   to create the `base` model are not included.
  *
  * @property {string} stopReason
  *   Output only. The reason that this create model operation stopped,
- *   e.g. BUDGET_REACHED, CONVERGED.
+ *   e.g. `BUDGET_REACHED`, `MODEL_CONVERGED`.
+ *
+ * @property {string} modelType
+ *   Optional. Type of the model. The available values are:
+ *   *   `cloud` - Model to be used via prediction calls to AutoML API.
+ *                 This is the default value.
+ *   *   `mobile-low-latency-1` - A model that, in addition to providing
+ *                 prediction via AutoML API, can also be exported (see
+ *                 AutoMl.ExportModel) and used on a mobile or edge device
+ *                 with TensorFlow afterwards. Expected to have low latency, but
+ *                 may have lower prediction quality than other models.
+ *   *   `mobile-versatile-1` - A model that, in addition to providing
+ *                 prediction via AutoML API, can also be exported (see
+ *                 AutoMl.ExportModel) and used on a mobile or edge device
+ *                 with TensorFlow afterwards.
+ *   *   `mobile-high-accuracy-1` - A model that, in addition to providing
+ *                 prediction via AutoML API, can also be exported (see
+ *                 AutoMl.ExportModel) and used on a mobile or edge device
+ *                 with TensorFlow afterwards.  Expected to have a higher
+ *                 latency, but should also have a higher prediction quality
+ *                 than other models.
+ *   *   `mobile-core-ml-low-latency-1` - A model that, in addition to providing
+ *                 prediction via AutoML API, can also be exported (see
+ *                 AutoMl.ExportModel) and used on a mobile device with Core
+ *                 ML afterwards. Expected to have low latency, but may have
+ *                 lower prediction quality than other models.
+ *   *   `mobile-core-ml-versatile-1` - A model that, in addition to providing
+ *                 prediction via AutoML API, can also be exported (see
+ *                 AutoMl.ExportModel) and used on a mobile device with Core
+ *                 ML afterwards.
+ *   *   `mobile-core-ml-high-accuracy-1` - A model that, in addition to
+ *                 providing prediction via AutoML API, can also be exported
+ *                 (see AutoMl.ExportModel) and used on a mobile device with
+ *                 Core ML afterwards.  Expected to have a higher latency, but
+ *                 should also have a higher prediction quality than other
+ *                 models.
  *
  * @typedef ImageClassificationModelMetadata
  * @memberof google.cloud.automl.v1beta1
  * @see [google.cloud.automl.v1beta1.ImageClassificationModelMetadata definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/image.proto}
  */
 const ImageClassificationModelMetadata = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Model metadata specific to image object detection.
+ *
+ * @property {string} modelType
+ *   Optional. Type of the model. The available values are:
+ *   *   `cloud-high-accuracy-1` - (default) A model to be used via prediction
+ *                 calls to AutoML API. Expected to have a higher latency, but
+ *                 should also have a higher prediction quality than other
+ *                 models.
+ *   *   `cloud-low-latency-1` -  A model to be used via prediction
+ *                 calls to AutoML API. Expected to have low latency, but may
+ *                 have lower prediction quality than other models.
+ *
+ * @property {number} nodeCount
+ *   Output only. The number of nodes this model is deployed on. A node is an
+ *   abstraction of a machine resource, which can handle online prediction QPS
+ *   as given in the qps_per_node field.
+ *
+ * @property {number} nodeQps
+ *   Output only. An approximate number of online prediction QPS that can
+ *   be supported by this model per each node on which it is deployed.
+ *
+ * @typedef ImageObjectDetectionModelMetadata
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.ImageObjectDetectionModelMetadata definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/image.proto}
+ */
+const ImageObjectDetectionModelMetadata = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Model deployment metadata specific to Image Object Detection.
+ *
+ * @property {number} nodeCount
+ *   Input only. The number of nodes to deploy the model on. A node is an
+ *   abstraction of a machine resource, which can handle online prediction QPS
+ *   as given in the model's
+ *
+ *   qps_per_node.
+ *   Must be between 1 and 100, inclusive on both ends.
+ *
+ * @typedef ImageObjectDetectionModelDeploymentMetadata
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.ImageObjectDetectionModelDeploymentMetadata definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/image.proto}
+ */
+const ImageObjectDetectionModelDeploymentMetadata = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };

--- a/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_io.js
+++ b/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_io.js
@@ -16,12 +16,250 @@
 // to be loaded as the JS file.
 
 /**
- * Input configuration.
+ * Input configuration for ImportData Action.
+ *
+ * The format of input depends on dataset_metadata the Dataset into which
+ * the import is happening has. As input source the
+ * gcs_source
+ * is expected, unless specified otherwise. If a file with identical content
+ * (even if it had different GCS_FILE_PATH) is mentioned multiple times , then
+ * its label, bounding boxes etc. are appended. The same file should be always
+ * provided with the same ML_USE and GCS_FILE_PATH, if it is not then
+ * these values are nondeterministically selected from the given ones.
+ *
+ * The formats are represented in EBNF with commas being literal and with
+ * non-terminal symbols defined near the end of this comment. The formats are:
+ *
+ *  *  For Image Object Detection:
+ *         CSV file(s) with each line in format:
+ *           ML_USE,GCS_FILE_PATH,LABEL,BOUNDING_BOX
+ *           GCS_FILE_PATH leads to image of up to 30MB in size. Supported
+ *           extensions: .JPEG, .GIF, .PNG.
+ *           Each image is assumed to be exhaustively labeled. The
+ *           minimum allowed BOUNDING_BOX edge length is 0.01, and no more than
+ *           500 BOUNDING_BOX-es per image are allowed.
+ *         Three sample rows:
+ *           TRAIN,gs://folder/image1.png,car,0.1,0.1,,,0.3,0.3,,
+ *           TRAIN,gs://folder/image1.png,bike,.7,.6,,,.8,.9,,
+ *           TEST,gs://folder/im2.png,car,0.1,0.1,0.2,0.1,0.2,0.3,0.1,0.3
+ *
+ *
+ *  *  For Video Classification:
+ *         CSV file(s) with each line in format:
+ *           ML_USE,GCS_FILE_PATH
+ *           where ML_USE VALIDATE value should not be used. The GCS_FILE_PATH
+ *           should lead to another .csv file which describes examples that have
+ *           given ML_USE, using the following row format:
+ *           GCS_FILE_PATH,LABEL,TIME_SEGMENT_START,TIME_SEGMENT_END
+ *           Here GCS_FILE_PATH leads to a video of up to 50GB in size and up
+ *           to 3h duration. Supported extensions: .MOV, .MPEG4, .MP4, .AVI.
+ *           TIME_SEGMENT_START and TIME_SEGMENT_END must be within the
+ *           length of the video, and end has to be after the start. Any segment
+ *           of a video which has one or more labels on it, is considered a
+ *           hard negative for all other labels. Any segment with no labels on
+ *           it is considered to be unknown.
+ *         Sample top level CSV file:
+ *           TRAIN,gs://folder/train_videos.csv
+ *           TEST,gs://folder/test_videos.csv
+ *           UNASSIGNED,gs://folder/other_videos.csv
+ *         Three sample rows of a CSV file for a particular ML_USE:
+ *           gs://folder/video1.avi,car,120,180.000021
+ *           gs://folder/video1.avi,bike,150,180.000021
+ *           gs://folder/vid2.avi,car,0,60.5
+ *  *  For Text Extraction:
+ *         CSV file(s) with each line in format:
+ *           ML_USE,GCS_FILE_PATH
+ *           GCS_FILE_PATH leads to a .JSONL (i.e. JSON Lines) file which either
+ *           imports text in-line or as documents.
+ *           The in-line .JSONL file contains, per line, a proto that wraps a
+ *             TextSnippet proto (in json representation) followed by one or
+ *             more AnnotationPayload protos (called annotations), which have
+ *             display_name and text_extraction detail populated.
+ *             Given text is expected to be annotated exhaustively, e.g. if you
+ *             look for animals and text contains "dolphin" that is not labeled,
+ *             then "dolphin" will be assumed to not be an animal.
+ *             Any given text snippet content must have 30,000 characters or
+ *             less, and also be UTF-8 NFC encoded (ASCII already is).
+ *           The document .JSONL file contains, per line, a proto that wraps a
+ *             Document proto with input_config set. Only PDF documents are
+ *             supported now, and each document may be up to 2MB large.
+ *             Currently annotations on documents cannot be specified at import.
+ *           Any given .JSONL file must be 100MB or smaller.
+ *         Three sample CSV rows:
+ *           TRAIN,gs://folder/file1.jsonl
+ *           VALIDATE,gs://folder/file2.jsonl
+ *           TEST,gs://folder/file3.jsonl
+ *         Sample in-line JSON Lines file (presented here with artificial line
+ *         breaks, but the only actual line break is denoted by \n).:
+ *           {
+ *             "text_snippet": {
+ *               "content": "dog car cat"
+ *             },
+ *             "annotations": [
+ *                {
+ *                  "display_name": "animal",
+ *                  "text_extraction": {
+ *                    "text_segment": {"start_offset": 0, "end_offset": 2}
+ *                  }
+ *                },
+ *                {
+ *                  "display_name": "vehicle",
+ *                  "text_extraction": {
+ *                    "text_segment": {"start_offset": 4, "end_offset": 6}
+ *                  }
+ *                },
+ *                {
+ *                  "display_name": "animal",
+ *                  "text_extraction": {
+ *                    "text_segment": {"start_offset": 8, "end_offset": 10}
+ *                  }
+ *                }
+ *             ]
+ *           }\n
+ *           {
+ *              "text_snippet": {
+ *                "content": "This dog is good."
+ *              },
+ *              "annotations": [
+ *                 {
+ *                   "display_name": "animal",
+ *                   "text_extraction": {
+ *                     "text_segment": {"start_offset": 5, "end_offset": 7}
+ *                   }
+ *                 }
+ *              ]
+ *           }
+ *         Sample document JSON Lines file (presented here with artificial line
+ *         breaks, but the only actual line break is denoted by \n).:
+ *           {
+ *             "document": {
+ *               "input_config": {
+ *                 "gcs_source": { "input_uris": [ "gs://folder/document1.pdf" ]
+ *                 }
+ *               }
+ *             }
+ *           }\n
+ *           {
+ *             "document": {
+ *               "input_config": {
+ *                 "gcs_source": { "input_uris": [ "gs://folder/document2.pdf" ]
+ *                 }
+ *               }
+ *             }
+ *           }
+ *   *  For Tables:
+ *         Either
+ *         gcs_source or
+ *
+ * bigquery_source
+ *         can be used. All inputs will be concatenated into a single
+ *
+ * primary_table
+ *         For gcs_source:
+ *           CSV file(s), where first file must have a header containing unique
+ *           column names, other files may have such header line too, and all
+ *           other lines contain values for the header columns. Each line must
+ *           have 1,000,000 or fewer characters.
+ *           First three sample rows of a CSV file:
+ *           "Id","First Name","Last Name","Dob","Addresses"
+ *
+ * "1","John","Doe","1968-01-22","[{"status":"current","address":"123_First_Avenue","city":"Seattle","state":"WA","zip":"11111","numberOfYears":"1"},{"status":"previous","address":"456_Main_Street","city":"Portland","state":"OR","zip":"22222","numberOfYears":"5"}]"
+ *
+ * "2","Jane","Doe","1980-10-16","[{"status":"current","address":"789_Any_Avenue","city":"Albany","state":"NY","zip":"33333","numberOfYears":"2"},{"status":"previous","address":"321_Main_Street","city":"Hoboken","state":"NJ","zip":"44444","numberOfYears":"3"}]}
+ *         For bigquery_source:
+ *           An URI of a BigQuery table.
+ *         An imported table must have between 2 and 1,000 columns, inclusive,
+ *         and between 1,000 and 10,000,000 rows, inclusive.
+ *
+ *  *  For Text Sentiment:
+ *         CSV file(s) with each line in format:
+ *           ML_USE,TEXT_SNIPPET,SENTIMENT
+ *           TEXT_SNIPPET must have up to 500 characters.
+ *         Three sample rows:
+ *         TRAIN,"@freewrytin God is way too good for Claritin",2
+ *         TRAIN,"I need Claritin so bad",3
+ *         TEST,"Thank god for Claritin.",4
+ *
+ *  Definitions:
+ *  ML_USE = "TRAIN" | "VALIDATE" | "TEST" | "UNASSIGNED"
+ *           Describes how the given example (file) should be used for model
+ *           training. "UNASSIGNED" can be used when user has no preference.
+ *  GCS_FILE_PATH = A path to file on GCS, e.g. "gs://folder/image1.png".
+ *  LABEL = A display name of an object on an image, video etc., e.g. "dog".
+ *          Must be up to 32 characters long and can consist only of ASCII
+ *          Latin letters A-Z and a-z, underscores(_), and ASCII digits 0-9.
+ *          For each label an AnnotationSpec is created which display_name
+ *          becomes the label; AnnotationSpecs are given back in predictions.
+ *  INSTANCE_ID = A positive integer that identifies a specific instance of a
+ *                labeled entity on an example. Used e.g. to track two cars on
+ *                a video while being able to tell apart which one is which.
+ *  BOUNDING_BOX = VERTEX,VERTEX,VERTEX,VERTEX | VERTEX,,,VERTEX,,
+ *                 A rectangle parallel to the frame of the example (image,
+ *                 video). If 4 vertices are given they are connected by edges
+ *                 in the order provided, if 2 are given they are recognized
+ *                 as diagonally opposite vertices of the rectangle.
+ *  VERTEX = COORDINATE,COORDINATE
+ *           First coordinate is horizontal (x), the second is vertical (y).
+ *  COORDINATE = A float in 0 to 1 range, relative to total length of
+ *               image or video in given dimension. For fractions the
+ *               leading non-decimal 0 can be omitted (i.e. 0.3 = .3).
+ *               Point 0,0 is in top left.
+ *  TIME_SEGMENT_START = TIME_OFFSET
+ *                       Expresses a beginning, inclusive, of a time segment
+ *                       within an example that has a time dimension
+ *                       (e.g. video).
+ *  TIME_SEGMENT_END = TIME_OFFSET
+ *                     Expresses an end, exclusive, of a time segment within
+ *                     an example that has a time dimension (e.g. video).
+ *  TIME_OFFSET = A number of seconds as measured from the start of an
+ *                example (e.g. video). Fractions are allowed, up to a
+ *                microsecond precision. "inf" is allowed, and it means the end
+ *                of the example.
+ *  TEXT_SNIPPET = A content of a text snippet, UTF-8 encoded.
+ *  SENTIMENT = An integer between 0 and
+ *              Dataset.text_sentiment_dataset_metadata.sentiment_max
+ *              (inclusive). Describes the ordinal of the sentiment - higher
+ *              value means a more positive sentiment. All the values are
+ *              completely relative, i.e. neither 0 needs to mean a negative or
+ *              neutral sentiment nor sentiment_max needs to mean a positive one
+ *              - it is just required that 0 is the least positive sentiment
+ *              in the data, and sentiment_max is the  most positive one.
+ *              The SENTIMENT shouldn't be confused with "score" or "magnitude"
+ *              from the previous Natural Language Sentiment Analysis API.
+ *              All SENTIMENT values between 0 and sentiment_max must be
+ *              represented in the imported data. On prediction the same 0 to
+ *              sentiment_max range will be used. The difference between
+ *              neighboring sentiment values needs not to be uniform, e.g. 1 and
+ *              2 may be similar whereas the difference between 2 and 3 may be
+ *              huge.
+ *
+ *  Errors:
+ *  If any of the provided CSV files can't be parsed or if more than certain
+ *  percent of CSV rows cannot be processed then the operation fails and
+ *  nothing is imported. Regardless of overall success or failure the per-row
+ *  failures, up to a certain count cap, will be listed in
+ *  Operation.metadata.partial_failures.
  *
  * @property {Object} gcsSource
- *   The GCS location for the input content.
+ *   The Google Cloud Storage location for the input content.
  *
  *   This object should have the same structure as [GcsSource]{@link google.cloud.automl.v1beta1.GcsSource}
+ *
+ * @property {Object} bigquerySource
+ *   The BigQuery location for the input content.
+ *
+ *   This object should have the same structure as [BigQuerySource]{@link google.cloud.automl.v1beta1.BigQuerySource}
+ *
+ * @property {Object.<string, string>} params
+ *   Additional domain-specific parameters describing the semantic of the
+ *   imported data, any string must be up to 25000
+ *   characters long.
+ *
+ *   *  For Tables:
+ *      `schema_inference_version` - (integer) Required. The version of the
+ *          algorithm that should be used for the initial inference of the
+ *          schema (columns' DataTypes) of the table the data is being imported
+ *          into. Allowed values: "1".
  *
  * @typedef InputConfig
  * @memberof google.cloud.automl.v1beta1
@@ -32,12 +270,244 @@ const InputConfig = {
 };
 
 /**
- * Output configuration.
+ * Input configuration for BatchPredict Action.
+ *
+ * The format of input depends on the ML problem of the model used for
+ * prediction. As input source the
+ * gcs_source
+ * is expected, unless specified otherwise.
+ *
+ * The formats are represented in EBNF with commas being literal and with
+ * non-terminal symbols defined near the end of this comment. The formats are:
+ *
+ *  *  For Video Classification:
+ *         CSV file(s) with each line in format:
+ *           GCS_FILE_PATH,TIME_SEGMENT_START,TIME_SEGMENT_END
+ *           GCS_FILE_PATH leads to video of up to 50GB in size and up to 3h
+ *           duration. Supported extensions: .MOV, .MPEG4, .MP4, .AVI.
+ *           TIME_SEGMENT_START and TIME_SEGMENT_END must be within the
+ *           length of the video, and end has to be after the start.
+ *         Three sample rows:
+ *           gs://folder/video1.mp4,10,40
+ *           gs://folder/video1.mp4,20,60
+ *           gs://folder/vid2.mov,0,inf
+ *
+ *  * For Text Extraction
+ *         .JSONL (i.e. JSON Lines) file(s) which either provide text in-line or
+ *         as documents (for a single BatchPredict call only one of the these
+ *         formats may be used).
+ *         The in-line .JSONL file(s) contain per line a proto that
+ *           wraps a temporary user-assigned TextSnippet ID (string up to 2000
+ *           characters long) called "id" followed by a TextSnippet proto (in
+ *           json representation). Any given text snippet content must have
+ *           30,000 characters or less, and also be UTF-8 NFC encoded (ASCII
+ *           already is). The IDs provided should be unique.
+ *         The document .JSONL file(s) contain, per line, a proto that wraps a
+ *           Document proto with input_config set. Only PDF documents are
+ *           supported now, and each document must be up to 2MB large.
+ *         Any given .JSONL file must be 100MB or smaller, and no more than 20
+ *         files may be given.
+ *         Sample in-line JSON Lines file (presented here with artificial line
+ *         breaks, but the only actual line break is denoted by \n):
+ *           {
+ *             "id": "my_first_id",
+ *             "text_snippet": { "content": "dog car cat"}
+ *           }\n
+ *           {
+ *             "id": "2",
+ *             "text_snippet": {
+ *               "content": "An elaborate content",
+ *               "mime_type": "text/plain"
+ *             }
+ *           }
+ *         Sample document JSON Lines file (presented here with artificial line
+ *         breaks, but the only actual line break is denoted by \n).:
+ *           {
+ *             "document": {
+ *               "input_config": {
+ *                 "gcs_source": { "input_uris": [ "gs://folder/document1.pdf" ]
+ *                 }
+ *               }
+ *             }
+ *           }\n
+ *           {
+ *             "document": {
+ *               "input_config": {
+ *                 "gcs_source": { "input_uris": [ "gs://folder/document2.pdf" ]
+ *                 }
+ *               }
+ *             }
+ *           }
+ *
+ *  *  For Tables:
+ *         Either
+ *         gcs_source or
+ *
+ * bigquery_source.
+ *         For gcs_source:
+ *           CSV file(s), where first file must have a header containing
+ *           column names, other files may have such header line too, and all
+ *           other lines contain values for the header columns. The column
+ *           names must be exactly same (order may differ) as the model's
+ *
+ * input_feature_column_specs'
+ *           display_names, with
+ *           values compatible with these column specs data types.
+ *           Prediction on all the rows, i.e. the CSV lines, will be
+ *           attempted.
+ *           Each line must have 1,000,000 or fewer characters.
+ *           First three sample rows of a CSV file:
+ *           "First Name","Last Name","Dob","Addresses"
+ *
+ * "John","Doe","1968-01-22","[{"status":"current","address":"123_First_Avenue","city":"Seattle","state":"WA","zip":"11111","numberOfYears":"1"},{"status":"previous","address":"456_Main_Street","city":"Portland","state":"OR","zip":"22222","numberOfYears":"5"}]"
+ *
+ * "Jane","Doe","1980-10-16","[{"status":"current","address":"789_Any_Avenue","city":"Albany","state":"NY","zip":"33333","numberOfYears":"2"},{"status":"previous","address":"321_Main_Street","city":"Hoboken","state":"NJ","zip":"44444","numberOfYears":"3"}]}
+ *         For bigquery_source:
+ *           An URI of a BigQuery table. The table's columns must be exactly
+ *           same (order may differ) as all model's
+ *
+ * input_feature_column_specs'
+ *           display_names, with
+ *           data compatible with these colum specs data types.
+ *           Prediction on all the rows of the table will be attempted.
+ *
+ *  Definitions:
+ *  GCS_FILE_PATH = A path to file on GCS, e.g. "gs://folder/video.avi".
+ *  TIME_SEGMENT_START = TIME_OFFSET
+ *                       Expresses a beginning, inclusive, of a time segment
+ *                       within an
+ *                       example that has a time dimension (e.g. video).
+ *  TIME_SEGMENT_END = TIME_OFFSET
+ *                     Expresses an end, exclusive, of a time segment within
+ *                     an example that has a time dimension (e.g. video).
+ *  TIME_OFFSET = A number of seconds as measured from the start of an
+ *                example (e.g. video). Fractions are allowed, up to a
+ *                microsecond precision. "inf" is allowed and it means the end
+ *                of the example.
+ *
+ *  Errors:
+ *  If any of the provided CSV files can't be parsed or if more than certain
+ *  percent of CSV rows cannot be processed then the operation fails and
+ *  prediction does not happen. Regardless of overall success or failure the
+ *  per-row failures, up to a certain count cap, will be listed in
+ *  Operation.metadata.partial_failures.
+ *
+ * @property {Object} gcsSource
+ *   The Google Cloud Storage location for the input content.
+ *
+ *   This object should have the same structure as [GcsSource]{@link google.cloud.automl.v1beta1.GcsSource}
+ *
+ * @property {Object} bigquerySource
+ *   The BigQuery location for the input content.
+ *
+ *   This object should have the same structure as [BigQuerySource]{@link google.cloud.automl.v1beta1.BigQuerySource}
+ *
+ * @typedef BatchPredictInputConfig
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.BatchPredictInputConfig definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/io.proto}
+ */
+const BatchPredictInputConfig = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Input configuration of a Document.
+ *
+ * @property {Object} gcsSource
+ *   The Google Cloud Storage location of the document file. Only a single path
+ *   should be given.
+ *   Max supported size: 512MB.
+ *   Supported extensions: .PDF.
+ *
+ *   This object should have the same structure as [GcsSource]{@link google.cloud.automl.v1beta1.GcsSource}
+ *
+ * @typedef DocumentInputConfig
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.DocumentInputConfig definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/io.proto}
+ */
+const DocumentInputConfig = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Output configuration for ExportData.
+ *
+ * As destination the
+ * gcs_destination
+ * must be set unless specified otherwise for a domain.
+ * Only ground truth annotations are exported (not approved annotations are
+ * not exported).
+ *
+ * The outputs correspond to how the data was imported, and may be used as
+ * input to import data. The output formats are represented as EBNF with literal
+ * commas and same non-terminal symbols definitions are these in import data's
+ * InputConfig:
+ *
+ *  *  For Image Object Detection:
+ *         CSV file(s) `image_object_detection_1.csv`,
+ *         `image_object_detection_2.csv`,...,`image_object_detection_N.csv`
+ *         with each line in format:
+ *         ML_USE,GCS_FILE_PATH,LABEL,BOUNDING_BOX
+ *         where GCS_FILE_PATHs point at the original, source locations of the
+ *         imported images.
+ *
+ *  *  For Video Classification:
+ *         CSV file `video_classification.csv`, with each line in format:
+ *         ML_USE,GCS_FILE_PATH
+ *         (may have muliple lines per a single ML_USE).
+ *         Each GCS_FILE_PATH leads to another .csv file which
+ *         describes examples that have given ML_USE, using the following
+ *         row format:
+ *         GCS_FILE_PATH,LABEL,TIME_SEGMENT_START,TIME_SEGMENT_END
+ *         Here GCS_FILE_PATHs point at the original, source locations of the
+ *         imported videos.
+ *  *  For Text Extraction:
+ *         CSV file `text_extraction.csv`, with each line in format:
+ *         ML_USE,GCS_FILE_PATH
+ *         GCS_FILE_PATH leads to a .JSONL (i.e. JSON Lines) file which
+ *         contains, per line, a proto that wraps a TextSnippet proto (in json
+ *         representation) followed by AnnotationPayload protos (called
+ *         annotations). If initially documents had been imported, corresponding
+ *         OCR-ed representation is returned.
+ *
+ *   *  For Tables:
+ *         Output depends on whether the dataset was imported from GCS or
+ *         BigQuery.
+ *         GCS case:
+ *
+ * gcs_destination
+ *           must be set. Exported are CSV file(s) `tables_1.csv`,
+ *           `tables_2.csv`,...,`tables_N.csv` with each having as header line
+ *           the table's column names, and all other lines contain values for
+ *           the header columns.
+ *         BigQuery case:
+ *
+ * bigquery_destination
+ *           pointing to a BigQuery project must be set. In the given project a
+ *           new dataset will be created with name
+ *
+ * `export_data_<automl-dataset-display-name>_<timestamp-of-export-call>`
+ *           where <automl-dataset-display-name> will be made
+ *           BigQuery-dataset-name compatible (e.g. most special characters will
+ *           become underscores), and timestamp will be in
+ *           YYYY_MM_DDThh_mm_ss_sssZ "based on ISO-8601" format. In that
+ *           dataset a new table called `primary_table` will be created, and
+ *           filled with precisely the same data as this obtained on import.
  *
  * @property {Object} gcsDestination
- *   The GCS location where the output must be written to.
+ *   The Google Cloud Storage location where the output is to be written to.
+ *   For Image Object Detection, Text Extraction, Video Classification and
+ *   Tables, in the given directory a new directory will be created with name:
+ *   export_data-<dataset-display-name>-<timestamp-of-export-call>
+ *   where timestamp is in YYYY-MM-DDThh:mm:ss.sssZ ISO-8601 format. All
+ *   export output will be written into that directory.
  *
  *   This object should have the same structure as [GcsDestination]{@link google.cloud.automl.v1beta1.GcsDestination}
+ *
+ * @property {Object} bigqueryDestination
+ *   The BigQuery location where the output is to be written to.
+ *
+ *   This object should have the same structure as [BigQueryDestination]{@link google.cloud.automl.v1beta1.BigQueryDestination}
  *
  * @typedef OutputConfig
  * @memberof google.cloud.automl.v1beta1
@@ -48,12 +518,308 @@ const OutputConfig = {
 };
 
 /**
- * The GCS location for the input content.
+ * Output configuration for BatchPredict Action.
+ *
+ * As destination the
+ *
+ * gcs_destination
+ * must be set unless specified otherwise for a domain. If gcs_destination is
+ * set then in the given directory a new directory will be created. Its name
+ * will be
+ * "prediction-<model-display-name>-<timestamp-of-prediction-call>",
+ * where timestamp is in YYYY-MM-DDThh:mm:ss.sssZ ISO-8601 format. The contents
+ * of it depend on the ML problem the predictions are made for.
+ *
+ *  *  For Video Classification:
+ *         In the created directory a video_classification.csv file, and a .JSON
+ *         file per each video classification requested in the input (i.e. each
+ *         line in given CSV(s)), will be created.
+ *
+ *         The format of video_classification.csv is:
+ *
+ * GCS_FILE_PATH,TIME_SEGMENT_START,TIME_SEGMENT_END,JSON_FILE_NAME,STATUS
+ *         where:
+ *         GCS_FILE_PATH,TIME_SEGMENT_START,TIME_SEGMENT_END = matches 1 to 1
+ *             the prediction input lines (i.e. video_classification.csv has
+ *             precisely the same number of lines as the prediction input had.)
+ *         JSON_FILE_NAME = Name of .JSON file in the output directory, which
+ *             contains prediction responses for the video time segment.
+ *         STATUS = "OK" if prediction completed successfully, or an error
+ *             code and,or message otherwise. If STATUS is not "OK" then the
+ *             .JSON file for that line may not exist or be empty.
+ *
+ *         Each .JSON file, assuming STATUS is "OK", will contain a list of
+ *         AnnotationPayload protos in JSON format, which are the predictions
+ *         for the video time segment the file is assigned to in the
+ *         video_classification.csv. All AnnotationPayload protos will have
+ *         video_classification field set, and will be sorted by
+ *         video_classification.type field (note that the returned types are
+ *         governed by `classifaction_types` parameter in
+ *         PredictService.BatchPredictRequest.params).
+ *   *  For Text Extraction:
+ *         In the created directory files `text_extraction_1.jsonl`,
+ *         `text_extraction_2.jsonl`,...,`text_extraction_N.jsonl`
+ *         will be created, where N may be 1, and depends on the
+ *         total number of inputs and annotations found.
+ *         The contents of these .JSONL file(s) depend on whether the input
+ *         used inline text, or documents.
+ *         If input was inline, then each .JSONL file will contain, per line,
+ *           a JSON representation of a proto that wraps given in request text
+ *           snippet's "id" : "<id_value>" followed by a list of zero or more
+ *           AnnotationPayload protos (called annotations), which have
+ *           text_extraction detail populated. A single text snippet will be
+ *           listed only once with all its annotations, and its annotations will
+ *           never be split across files.
+ *         If input used documents, then each .JSONL file will contain, per
+ *           line, a JSON representation of a proto that wraps given in request
+ *           document proto, followed by its OCR-ed representation in the form
+ *           of a text snippet, finally followed by a list of zero or more
+ *           AnnotationPayload protos (called annotations), which have
+ *           text_extraction detail populated and refer, via their indices, to
+ *           the OCR-ed text snippet. A single document (and its text snippet)
+ *           will be listed only once with all its annotations, and its
+ *           annotations will never be split across files.
+ *         If prediction for any text snippet failed (partially or completely),
+ *         then additional `errors_1.jsonl`, `errors_2.jsonl`,...,
+ *         `errors_N.jsonl` files will be created (N depends on total number of
+ *         failed predictions). These files will have a JSON representation of a
+ *         proto that wraps either the "id" : "<id_value>" (in case of inline)
+ *         or the document proto (in case of document) but here followed by
+ *         exactly one
+ *
+ * [`google.rpc.Status`](https:
+ * //github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
+ *         containing only `code` and `message`.
+ *
+ *  *  For Tables:
+ *         Output depends on whether
+ *
+ * gcs_destination
+ *         or
+ *
+ * bigquery_destination
+ *         is set (either is allowed).
+ *         GCS case:
+ *           In the created directory files `tables_1.csv`, `tables_2.csv`,...,
+ *           `tables_N.csv` will be created, where N may be 1, and depends on
+ *           the total number of the successfully predicted rows.
+ *           For the classification models:
+ *             Each .csv file will contain a header, listing all model's
+ *
+ * input_feature_column_specs'
+ *
+ * display_names
+ *             followed by M target column names in the format of
+ *
+ * "<target_column_specs
+ *
+ * display_name>_<target
+ *             value>_score" where M is the number of distinct target values,
+ *             i.e. number of distinct values in the target column of the table
+ *             used to train the model. Subsequent lines will contain the
+ *             respective values of successfully predicted rows, with the last,
+ *             i.e. the target, columns having the corresponding prediction
+ *             scores.
+ *           For the regression models:
+ *             Each .csv file will contain a header, listing all model's
+ *
+ * input_feature_column_specs
+ *             display_names
+ *             followed by the target column with name equal to
+ *
+ * target_column_specs'
+ *
+ * display_name.
+ *             Subsequent lines will contain the respective values of
+ *             successfully predicted rows, with the last, i.e. the target,
+ *             column having the predicted target value.
+ *           If prediction for any rows failed, then an additional
+ *           `errors_1.csv`, `errors_2.csv`,..., `errors_N.csv` will be created
+ *           (N depends on total number of failed rows). These files will have
+ *           analogous format as `tables_*.csv`, but always with a single target
+ *           column having
+ *
+ * [`google.rpc.Status`](https:
+ * //github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
+ *           represented as a JSON string, and containing only `code` and
+ *           `message`.
+ *        BigQuery case:
+ *
+ * bigquery_destination
+ *           pointing to a BigQuery project must be set. In the given project a
+ *           new dataset will be created with name
+ *           `prediction_<model-display-name>_<timestamp-of-prediction-call>`
+ *           where <model-display-name> will be made
+ *           BigQuery-dataset-name compatible (e.g. most special characters will
+ *           become underscores), and timestamp will be in
+ *           YYYY_MM_DDThh_mm_ss_sssZ "based on ISO-8601" format. In the dataset
+ *           two tables will be created, `predictions`, and `errors`.
+ *           The `predictions` table's column names will be the
+ *
+ * input_feature_column_specs'
+ *
+ * display_names
+ *           followed by model's
+ *
+ * target_column_specs'
+ *
+ * display_name.
+ *           The input feature columns will contain the respective values of
+ *           successfully predicted rows, with the target column having an
+ *           ARRAY of
+ *
+ * AnnotationPayloads,
+ *           represented as STRUCT-s, containing
+ *           TablesAnnotation.
+ *           The `errors` table contains rows for which the prediction has
+ *           failed, it has analogous input feature and target columns, but
+ *           here the target column as a value has
+ *
+ * [`google.rpc.Status`](https:
+ * //github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
+ *           represented as a STRUCT, and containing only `code` and `message`.
+ *
+ * @property {Object} gcsDestination
+ *   The Google Cloud Storage location of the directory where the output is to
+ *   be written to.
+ *
+ *   This object should have the same structure as [GcsDestination]{@link google.cloud.automl.v1beta1.GcsDestination}
+ *
+ * @property {Object} bigqueryDestination
+ *   The BigQuery location where the output is to be written to.
+ *
+ *   This object should have the same structure as [BigQueryDestination]{@link google.cloud.automl.v1beta1.BigQueryDestination}
+ *
+ * @typedef BatchPredictOutputConfig
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.BatchPredictOutputConfig definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/io.proto}
+ */
+const BatchPredictOutputConfig = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Output configuration for ModelExport Action.
+ *
+ * @property {Object} gcsDestination
+ *   The Google Cloud Storage location where the model is to be written to.
+ *   This location may only be set for the following model formats:
+ *     "tflite", "edgetpu_tflite", "core_ml", "docker".
+ *
+ *    Under the directory given as the destination a new one with name
+ *    "model-export-<model-display-name>-<timestamp-of-export-call>",
+ *    where timestamp is in YYYY-MM-DDThh:mm:ss.sssZ ISO-8601 format,
+ *    will be created. Inside the model and any of its supporting files
+ *    will be written, as described
+ *
+ *   [here](https:
+ *   //cloud.google.com/vision/automl/alpha/d
+ *   // ocs/predict#deployment_to_devices).
+ *
+ *   This object should have the same structure as [GcsDestination]{@link google.cloud.automl.v1beta1.GcsDestination}
+ *
+ * @property {Object} gcrDestination
+ *   The GCR location where model image is to be pushed to. This location
+ *   may only be set for the following model formats:
+ *     "docker".
+ *
+ *   The model image will be created under the given URI.
+ *
+ *   This object should have the same structure as [GcrDestination]{@link google.cloud.automl.v1beta1.GcrDestination}
+ *
+ * @property {string} modelFormat
+ *   The format in which the model must be exported. The available, and default,
+ *   formats depend on the problem and model type (if given problem and type
+ *   combination doesn't have a format listed, it means its models are not
+ *   exportable):
+ *
+ *   *  For Image Classification mobile-low-latency-1, mobile-versatile-1,
+ *          mobile-high-accuracy-1:
+ *        "tflite" (default), "edgetpu_tflite", "tf_saved_model", "docker".
+ *
+ *   *  For Image Classification mobile-core-ml-low-latency-1,
+ *          mobile-core-ml-versatile-1, mobile-core-ml-high-accuracy-1:
+ *        "core_ml" (default).
+ *   Formats description:
+ *
+ *   * tflite - Used for Android mobile devices.
+ *   * edgetpu_tflite - Used for [Edge TPU](https://cloud.google.com/edge-tpu/)
+ *                      devices.
+ *   * tf_saved_model - A tensorflow model in SavedModel format.
+ *   * docker - Used for Docker containers. Use the params field to customize
+ *              the container. The container is verified to work correctly on
+ *              ubuntu 16.04 operating system.
+ *   * core_ml - Used for iOS mobile devices.
+ *
+ * @property {Object.<string, string>} params
+ *   Additional model-type and format specific parameters describing the
+ *   requirements for the to be exported model files, any string must be up to
+ *   25000 characters long.
+ *
+ *    * For `docker` format:
+ *       `cpu_architecture` - (string) "x86_64" (default).
+ *       `gpu_architecture` - (string) "none" (default), "nvidia".
+ *
+ * @typedef ModelExportOutputConfig
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.ModelExportOutputConfig definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/io.proto}
+ */
+const ModelExportOutputConfig = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Output configuration for ExportEvaluatedExamples Action. Note that this call
+ * is available only for 30 days since the moment the model was evaluated.
+ * The output depends on the domain, as follows (note that only examples from
+ * the TEST set are exported):
+ *
+ *  *  For Tables:
+ *
+ * bigquery_destination
+ *       pointing to a BigQuery project must be set. In the given project a
+ *       new dataset will be created with name
+ *
+ * `export_evaluated_examples_<model-display-name>_<timestamp-of-export-call>`
+ *       where <model-display-name> will be made BigQuery-dataset-name
+ *       compatible (e.g. most special characters will become underscores),
+ *       and timestamp will be in YYYY_MM_DDThh_mm_ss_sssZ "based on ISO-8601"
+ *       format. In the dataset an `evaluated_examples` table will be
+ *       created. It will have all the same columns as the
+ *       primary
+ *
+ * table
+ *       of the
+ *       dataset from which
+ *       the model was created, as they were at the moment of model's
+ *       evaluation (this includes the target column with its ground
+ *       truth), followed by a column called "predicted_<target_column>". That
+ *       last column will contain the model's prediction result for each
+ *       respective row, given as ARRAY of
+ *       AnnotationPayloads,
+ *       represented as STRUCT-s, containing
+ *       TablesAnnotation.
+ *
+ * @property {Object} bigqueryDestination
+ *   The BigQuery location where the output is to be written to.
+ *
+ *   This object should have the same structure as [BigQueryDestination]{@link google.cloud.automl.v1beta1.BigQueryDestination}
+ *
+ * @typedef ExportEvaluatedExamplesOutputConfig
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.ExportEvaluatedExamplesOutputConfig definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/io.proto}
+ */
+const ExportEvaluatedExamplesOutputConfig = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * The Google Cloud Storage location for the input content.
  *
  * @property {string[]} inputUris
  *   Required. Google Cloud Storage URIs to input files, up to 2000 characters
  *   long. Accepted forms:
- *   * Full object path: gs://bucket/directory/object.csv
+ *   * Full object path, e.g. gs://bucket/directory/object.csv
  *
  * @typedef GcsSource
  * @memberof google.cloud.automl.v1beta1
@@ -64,7 +830,23 @@ const GcsSource = {
 };
 
 /**
- * The GCS location where the output must be written to
+ * The BigQuery location for the input content.
+ *
+ * @property {string} inputUri
+ *   Required. BigQuery URI to a table, up to 2000 characters long.
+ *   Accepted forms:
+ *   *  BigQuery path e.g. bq://projectId.bqDatasetId.bqTableId
+ *
+ * @typedef BigQuerySource
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.BigQuerySource definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/io.proto}
+ */
+const BigQuerySource = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * The Google Cloud Storage location where the output is to be written to.
  *
  * @property {string} outputUriPrefix
  *   Required. Google Cloud Storage URI to output directory, up to 2000
@@ -79,5 +861,45 @@ const GcsSource = {
  * @see [google.cloud.automl.v1beta1.GcsDestination definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/io.proto}
  */
 const GcsDestination = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * The BigQuery location for the output content.
+ *
+ * @property {string} outputUri
+ *   Required. BigQuery URI to a project, up to 2000 characters long.
+ *   Accepted forms:
+ *   *  BigQuery path e.g. bq://projectId
+ *
+ * @typedef BigQueryDestination
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.BigQueryDestination definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/io.proto}
+ */
+const BigQueryDestination = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * The GCR location where the image must be pushed to.
+ *
+ * @property {string} outputUri
+ *   Required. Google Contained Registry URI of the new image, up to 2000
+ *   characters long. See
+ *
+ *   https:
+ *   //cloud.google.com/container-registry/do
+ *   // cs/pushing-and-pulling#pushing_an_image_to_a_registry
+ *   Accepted forms:
+ *   * [HOSTNAME]/[PROJECT-ID]/[IMAGE]
+ *   * [HOSTNAME]/[PROJECT-ID]/[IMAGE]:[TAG]
+ *
+ *   The requesting user must have permission to push images the project.
+ *
+ * @typedef GcrDestination
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.GcrDestination definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/io.proto}
+ */
+const GcrDestination = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };

--- a/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_io.js
+++ b/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_io.js
@@ -712,9 +712,7 @@ const BatchPredictOutputConfig = {
  *    will be created. Inside the model and any of its supporting files
  *    will be written, as described
  *
- *   [here](https:
- *   //cloud.google.com/vision/automl/alpha/d
- *   // ocs/predict#deployment_to_devices).
+ *   [here](https://cloud.google.com/vision/automl/alpha/docs/predict#deployment_to_devices).
  *
  *   This object should have the same structure as [GcsDestination]{@link google.cloud.automl.v1beta1.GcsDestination}
  *

--- a/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_io.js
+++ b/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_io.js
@@ -710,9 +710,7 @@ const BatchPredictOutputConfig = {
  *    "model-export-<model-display-name>-<timestamp-of-export-call>",
  *    where timestamp is in YYYY-MM-DDThh:mm:ss.sssZ ISO-8601 format,
  *    will be created. Inside the model and any of its supporting files
- *    will be written, as described
- *
- *   [here](https://cloud.google.com/vision/automl/alpha/docs/predict#deployment_to_devices).
+ *    will be written.
  *
  *   This object should have the same structure as [GcsDestination]{@link google.cloud.automl.v1beta1.GcsDestination}
  *

--- a/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_model.js
+++ b/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_model.js
@@ -18,6 +18,11 @@
 /**
  * API proto representing a trained machine learning model.
  *
+ * @property {Object} translationModelMetadata
+ *   Metadata for translation models.
+ *
+ *   This object should have the same structure as [TranslationModelMetadata]{@link google.cloud.automl.v1beta1.TranslationModelMetadata}
+ *
  * @property {Object} imageClassificationModelMetadata
  *   Metadata for image classification models.
  *
@@ -28,10 +33,30 @@
  *
  *   This object should have the same structure as [TextClassificationModelMetadata]{@link google.cloud.automl.v1beta1.TextClassificationModelMetadata}
  *
- * @property {Object} translationModelMetadata
- *   Metadata for translation models.
+ * @property {Object} imageObjectDetectionModelMetadata
+ *   Metadata for image object detection models.
  *
- *   This object should have the same structure as [TranslationModelMetadata]{@link google.cloud.automl.v1beta1.TranslationModelMetadata}
+ *   This object should have the same structure as [ImageObjectDetectionModelMetadata]{@link google.cloud.automl.v1beta1.ImageObjectDetectionModelMetadata}
+ *
+ * @property {Object} videoClassificationModelMetadata
+ *   Metadata for video classification models.
+ *
+ *   This object should have the same structure as [VideoClassificationModelMetadata]{@link google.cloud.automl.v1beta1.VideoClassificationModelMetadata}
+ *
+ * @property {Object} textExtractionModelMetadata
+ *   Metadata for text extraction models.
+ *
+ *   This object should have the same structure as [TextExtractionModelMetadata]{@link google.cloud.automl.v1beta1.TextExtractionModelMetadata}
+ *
+ * @property {Object} tablesModelMetadata
+ *   Metadata for Tables models.
+ *
+ *   This object should have the same structure as [TablesModelMetadata]{@link google.cloud.automl.v1beta1.TablesModelMetadata}
+ *
+ * @property {Object} textSentimentModelMetadata
+ *   Metadata for text sentiment models.
+ *
+ *   This object should have the same structure as [TextSentimentModelMetadata]{@link google.cloud.automl.v1beta1.TextSentimentModelMetadata}
  *
  * @property {string} name
  *   Output only.
@@ -40,15 +65,14 @@
  *
  * @property {string} displayName
  *   Required. The name of the model to show in the interface. The name can be
- *   up to 32 characters
- *   long and can consist only of ASCII Latin letters A-Z and a-z, underscores
- *   (_), and ASCII digits 0-9.
+ *   up to 32 characters long and can consist only of ASCII Latin letters A-Z
+ *   and a-z, underscores
+ *   (_), and ASCII digits 0-9. It must start with a letter.
  *
  * @property {string} datasetId
  *   Required.
  *   The resource ID of the dataset used to create the model. The dataset must
- *   come from the
- *   same ancestor project and location.
+ *   come from the same ancestor project and location.
  *
  * @property {Object} createTime
  *   Output only.
@@ -63,7 +87,8 @@
  *   This object should have the same structure as [Timestamp]{@link google.protobuf.Timestamp}
  *
  * @property {number} deploymentState
- *   Output only. Deployment state of the model.
+ *   Output only. Deployment state of the model. A model can only serve
+ *   prediction requests after it gets deployed.
  *
  *   The number should be among the values of [DeploymentState]{@link google.cloud.automl.v1beta1.DeploymentState}
  *

--- a/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_model_evaluation.js
+++ b/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_model_evaluation.js
@@ -19,14 +19,39 @@
  * Evaluation results of a model.
  *
  * @property {Object} classificationEvaluationMetrics
- *   Evaluation metrics for models on classification problems models.
+ *   Model evaluation metrics for image, text, video and tables
+ *   classification.
+ *   Tables problem is considered a classification when the target column
+ *   has either CATEGORY or ARRAY(CATEGORY) DataType.
  *
  *   This object should have the same structure as [ClassificationEvaluationMetrics]{@link google.cloud.automl.v1beta1.ClassificationEvaluationMetrics}
  *
+ * @property {Object} regressionEvaluationMetrics
+ *   Model evaluation metrics for Tables regression.
+ *   Tables problem is considered a regression when the target column
+ *   has FLOAT64 DataType.
+ *
+ *   This object should have the same structure as [RegressionEvaluationMetrics]{@link google.cloud.automl.v1beta1.RegressionEvaluationMetrics}
+ *
  * @property {Object} translationEvaluationMetrics
- *   Evaluation metrics for models on translation models.
+ *   Model evaluation metrics for translation.
  *
  *   This object should have the same structure as [TranslationEvaluationMetrics]{@link google.cloud.automl.v1beta1.TranslationEvaluationMetrics}
+ *
+ * @property {Object} imageObjectDetectionEvaluationMetrics
+ *   Model evaluation metrics for image object detection.
+ *
+ *   This object should have the same structure as [ImageObjectDetectionEvaluationMetrics]{@link google.cloud.automl.v1beta1.ImageObjectDetectionEvaluationMetrics}
+ *
+ * @property {Object} textSentimentEvaluationMetrics
+ *   Evaluation metrics for text sentiment models.
+ *
+ *   This object should have the same structure as [TextSentimentEvaluationMetrics]{@link google.cloud.automl.v1beta1.TextSentimentEvaluationMetrics}
+ *
+ * @property {Object} textExtractionEvaluationMetrics
+ *   Evaluation metrics for text extraction models.
+ *
+ *   This object should have the same structure as [TextExtractionEvaluationMetrics]{@link google.cloud.automl.v1beta1.TextExtractionEvaluationMetrics}
  *
  * @property {string} name
  *   Output only.
@@ -38,10 +63,21 @@
  * @property {string} annotationSpecId
  *   Output only.
  *   The ID of the annotation spec that the model evaluation applies to. The
- *   ID is empty for overall model evaluation.
+ *   The ID is empty for the overall model evaluation.
+ *   For Tables classification these are the distinct values of the target
+ *   column at the moment of the evaluation; for this problem annotation specs
+ *   in the dataset do not exist.
  *   NOTE: Currently there is no way to obtain the display_name of the
  *   annotation spec from its ID. To see the display_names, review the model
  *   evaluations in the UI.
+ *
+ * @property {string} displayName
+ *   Output only. The value of AnnotationSpec.display_name when the model
+ *   was trained. Because this field returns a value at model training time,
+ *   for different models trained using the same dataset, the returned value
+ *   could be different as model owner could update the display_name between
+ *   any two model training.
+ *   The display_name is empty for the overall model evaluation.
  *
  * @property {Object} createTime
  *   Output only.
@@ -50,7 +86,16 @@
  *   This object should have the same structure as [Timestamp]{@link google.protobuf.Timestamp}
  *
  * @property {number} evaluatedExampleCount
- *   Output only. The number of examples used for model evaluation.
+ *   Output only.
+ *   The number of examples used for model evaluation, i.e. for
+ *   which ground truth from time of model creation is compared against the
+ *   predicted annotations created by the model.
+ *   For overall ModelEvaluation (i.e. with annotation_spec_id not set) this is
+ *   the total number of all examples used for evaluation.
+ *   Otherwise, this is the count of examples that according to the ground
+ *   truth were annotated by the
+ *
+ *   annotation_spec_id.
  *
  * @typedef ModelEvaluation
  * @memberof google.cloud.automl.v1beta1

--- a/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_prediction_service.js
+++ b/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_prediction_service.js
@@ -16,8 +16,7 @@
 // to be loaded as the JS file.
 
 /**
- * Request message for
- * PredictionService.Predict.
+ * Request message for PredictionService.Predict.
  *
  * @property {string} name
  *   Name of the model requested to serve the prediction.
@@ -36,9 +35,16 @@
  *   *  For Image Classification:
  *
  *      `score_threshold` - (float) A value from 0.0 to 1.0. When the model
- *       makes predictions for an
- *       image, it will only produce results that have at least this confidence
- *       score threshold. The default is 0.5.
+ *       makes predictions for an image, it will only produce results that have
+ *       at least this confidence score. The default is 0.5.
+ *
+ *    *  For Image Object Detection:
+ *      `score_threshold` - (float) When Model detects objects on the image,
+ *          it will only produce bounding boxes which have at least this
+ *          confidence score. Value in 0 to 1 range, default is 0.5.
+ *      `max_bounding_box_count` - (int64) No more than this number of bounding
+ *          boxes will be returned in the response. Default is 100, the
+ *          requested value may be limited by server.
  *
  * @typedef PredictRequest
  * @memberof google.cloud.automl.v1beta1
@@ -49,25 +55,102 @@ const PredictRequest = {
 };
 
 /**
- * Response message for
- * PredictionService.Predict.
- *
- * Currently, this is only
- * used to return an image recognition prediction result. More prediction
- * output metadata might be introduced in the future.
+ * Response message for PredictionService.Predict.
  *
  * @property {Object[]} payload
  *   Prediction result.
+ *   Translation and Text Sentiment will return precisely one payload.
  *
  *   This object should have the same structure as [AnnotationPayload]{@link google.cloud.automl.v1beta1.AnnotationPayload}
  *
  * @property {Object.<string, string>} metadata
  *   Additional domain-specific prediction response metadata.
  *
+ *   * For Image Object Detection:
+ *    `max_bounding_box_count` - (int64) At most that many bounding boxes per
+ *        image could have been returned.
+ *
+ *   * For Text Sentiment:
+ *    `sentiment_score` - (float, deprecated) A value between -1 and 1,
+ *        -1 maps to least positive sentiment, while 1 maps to the most positive
+ *        one and the higher the score, the more positive the sentiment in the
+ *        document is. Yet these values are relative to the training data, so
+ *        e.g. if all data was positive then -1 will be also positive (though
+ *        the least).
+ *        The sentiment_score shouldn't be confused with "score" or "magnitude"
+ *        from the previous Natural Language Sentiment Analysis API.
+ *
  * @typedef PredictResponse
  * @memberof google.cloud.automl.v1beta1
  * @see [google.cloud.automl.v1beta1.PredictResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/prediction_service.proto}
  */
 const PredictResponse = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Request message for PredictionService.BatchPredict.
+ *
+ * @property {string} name
+ *   Name of the model requested to serve the batch prediction.
+ *
+ * @property {Object} inputConfig
+ *   Required. The input configuration for batch prediction.
+ *
+ *   This object should have the same structure as [BatchPredictInputConfig]{@link google.cloud.automl.v1beta1.BatchPredictInputConfig}
+ *
+ * @property {Object} outputConfig
+ *   Required. The Configuration specifying where output predictions should
+ *   be written.
+ *
+ *   This object should have the same structure as [BatchPredictOutputConfig]{@link google.cloud.automl.v1beta1.BatchPredictOutputConfig}
+ *
+ * @property {Object.<string, string>} params
+ *   Additional domain-specific parameters for the predictions, any string must
+ *   be up to 25000 characters long.
+ *
+ *   *  For Video Classification :
+ *      `score_threshold` - (float) A value from 0.0 to 1.0. When the model
+ *          makes predictions for a video, it will only produce results that
+ *          have at least this confidence score. The default is 0.5.
+ *      `segment_classification` - (boolean) Set to true to request
+ *          segment-level classification. AutoML Video Intelligence returns
+ *          labels and their confidence scores for the entire segment of the
+ *          video that user specified in the request configuration.
+ *          The default is "true".
+ *      `shot_classification` - (boolean) Set to true to request shot-level
+ *          classification. AutoML Video Intelligence determines the boundaries
+ *          for each camera shot in the entire segment of the video that user
+ *          specified in the request configuration. AutoML Video Intelligence
+ *          then returns labels and their confidence scores for each detected
+ *          shot, along with the start and end time of the shot.
+ *          WARNING: Model evaluation is not done for this classification type,
+ *          the quality of it depends on training data, but there are no metrics
+ *          provided to describe that quality. The default is "false".
+ *      `1s_interval_classification` - (boolean) Set to true to request
+ *          classification for a video at one-second intervals. AutoML Video
+ *          Intelligence returns labels and their confidence scores for each
+ *          second of the entire segment of the video that user specified in the
+ *          request configuration.
+ *          WARNING: Model evaluation is not done for this classification
+ *          type, the quality of it depends on training data, but there are no
+ *          metrics provided to describe that quality. The default is
+ *          "false".
+ *
+ * @typedef BatchPredictRequest
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.BatchPredictRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/prediction_service.proto}
+ */
+const BatchPredictRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Batch predict result.
+ * @typedef BatchPredictResult
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.BatchPredictResult definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/prediction_service.proto}
+ */
+const BatchPredictResult = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };

--- a/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_ranges.js
+++ b/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_ranges.js
@@ -1,0 +1,33 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
+
+/**
+ * A range between two double numbers.
+ *
+ * @property {number} start
+ *   Start of the range, inclusive.
+ *
+ * @property {number} end
+ *   End of the range, exclusive.
+ *
+ * @typedef DoubleRange
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.DoubleRange definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/ranges.proto}
+ */
+const DoubleRange = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};

--- a/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_regression.js
+++ b/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_regression.js
@@ -1,0 +1,40 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
+
+/**
+ * Metrics for regression problems.
+ *
+ * @property {number} rootMeanSquaredError
+ *   Output only. Root Mean Squared Error (RMSE).
+ *
+ * @property {number} meanAbsoluteError
+ *   Output only. Mean Absolute Error (MAE).
+ *
+ * @property {number} meanAbsolutePercentageError
+ *   Output only. Mean absolute percentage error. Only set if all ground truth
+ *   values are are positive.
+ *
+ * @property {number} rSquared
+ *   Output only. R squared.
+ *
+ * @typedef RegressionEvaluationMetrics
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.RegressionEvaluationMetrics definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/regression.proto}
+ */
+const RegressionEvaluationMetrics = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};

--- a/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_service.js
+++ b/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_service.js
@@ -16,8 +16,7 @@
 // to be loaded as the JS file.
 
 /**
- * Request message for
- * AutoMl.CreateDataset.
+ * Request message for AutoMl.CreateDataset.
  *
  * @property {string} parent
  *   The resource name of the project to create the dataset for.
@@ -36,8 +35,7 @@ const CreateDatasetRequest = {
 };
 
 /**
- * Request message for
- * AutoMl.GetDataset.
+ * Request message for AutoMl.GetDataset.
  *
  * @property {string} name
  *   The resource name of the dataset to retrieve.
@@ -51,8 +49,7 @@ const GetDatasetRequest = {
 };
 
 /**
- * Request message for
- * AutoMl.ListDatasets.
+ * Request message for AutoMl.ListDatasets.
  *
  * @property {string} parent
  *   The resource name of the project from which to list datasets.
@@ -60,9 +57,8 @@ const GetDatasetRequest = {
  * @property {string} filter
  *   An expression for filtering the results of the request.
  *
- *     * `dataset_metadata` - for existence of the case.
- *
- *   An example of using the filter is:
+ *     * `dataset_metadata` - for existence of the case (e.g.
+ *               image_classification_dataset_metadata:*). Some examples of using the filter are:
  *
  *     * `translation_dataset_metadata:*` --> The dataset has
  *                                            translation_dataset_metadata.
@@ -74,10 +70,8 @@ const GetDatasetRequest = {
  * @property {string} pageToken
  *   A token identifying a page of results for the server to return
  *   Typically obtained via
- *   ListDatasetsResponse.next_page_token
- *   of the previous
- *   AutoMl.ListDatasets
- *   call.
+ *   ListDatasetsResponse.next_page_token of the previous
+ *   AutoMl.ListDatasets call.
  *
  * @typedef ListDatasetsRequest
  * @memberof google.cloud.automl.v1beta1
@@ -88,8 +82,7 @@ const ListDatasetsRequest = {
 };
 
 /**
- * Response message for
- * AutoMl.ListDatasets.
+ * Response message for AutoMl.ListDatasets.
  *
  * @property {Object[]} datasets
  *   The datasets read.
@@ -98,9 +91,7 @@ const ListDatasetsRequest = {
  *
  * @property {string} nextPageToken
  *   A token to retrieve next page of results.
- *   Pass to
- *   ListDatasetsRequest.page_token
- *   to obtain that page.
+ *   Pass to ListDatasetsRequest.page_token to obtain that page.
  *
  * @typedef ListDatasetsResponse
  * @memberof google.cloud.automl.v1beta1
@@ -111,8 +102,33 @@ const ListDatasetsResponse = {
 };
 
 /**
- * Request message for
- * AutoMl.DeleteDataset.
+ * Request message for AutoMl.UpdateDataset
+ *
+ * @property {Object} dataset
+ *   The dataset which replaces the resource on the server.
+ *
+ *   This object should have the same structure as [Dataset]{@link google.cloud.automl.v1beta1.Dataset}
+ *
+ * @property {Object} updateMask
+ *   The update mask applies to the resource. For the `FieldMask` definition,
+ *   see
+ *
+ *   https:
+ *   //developers.google.com/protocol-buffers
+ *   // /docs/reference/google.protobuf#fieldmask
+ *
+ *   This object should have the same structure as [FieldMask]{@link google.protobuf.FieldMask}
+ *
+ * @typedef UpdateDatasetRequest
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.UpdateDatasetRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/service.proto}
+ */
+const UpdateDatasetRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Request message for AutoMl.DeleteDataset.
  *
  * @property {string} name
  *   The resource name of the dataset to delete.
@@ -126,15 +142,15 @@ const DeleteDatasetRequest = {
 };
 
 /**
- * Request message for
- * AutoMl.ImportData.
+ * Request message for AutoMl.ImportData.
  *
  * @property {string} name
  *   Required. Dataset name. Dataset must already exist. All imported
  *   annotations and examples will be added.
  *
  * @property {Object} inputConfig
- *   Required. The desired input location.
+ *   Required. The desired input location and its domain specific semantics,
+ *   if any.
  *
  *   This object should have the same structure as [InputConfig]{@link google.cloud.automl.v1beta1.InputConfig}
  *
@@ -147,8 +163,7 @@ const ImportDataRequest = {
 };
 
 /**
- * Request message for
- * AutoMl.ExportData.
+ * Request message for AutoMl.ExportData.
  *
  * @property {string} name
  *   Required. The resource name of the dataset.
@@ -167,8 +182,215 @@ const ExportDataRequest = {
 };
 
 /**
- * Request message for
- * AutoMl.CreateModel.
+ * Request message for AutoMl.GetAnnotationSpec.
+ *
+ * @property {string} name
+ *   The resource name of the annotation spec to retrieve.
+ *
+ * @typedef GetAnnotationSpecRequest
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.GetAnnotationSpecRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/service.proto}
+ */
+const GetAnnotationSpecRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Request message for AutoMl.GetTableSpec.
+ *
+ * @property {string} name
+ *   The resource name of the table spec to retrieve.
+ *
+ * @property {Object} fieldMask
+ *   Mask specifying which fields to read.
+ *
+ *   This object should have the same structure as [FieldMask]{@link google.protobuf.FieldMask}
+ *
+ * @typedef GetTableSpecRequest
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.GetTableSpecRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/service.proto}
+ */
+const GetTableSpecRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Request message for AutoMl.ListTableSpecs.
+ *
+ * @property {string} parent
+ *   The resource name of the dataset to list table specs from.
+ *
+ * @property {Object} fieldMask
+ *   Mask specifying which fields to read.
+ *
+ *   This object should have the same structure as [FieldMask]{@link google.protobuf.FieldMask}
+ *
+ * @property {string} filter
+ *   Filter expression, see go/filtering.
+ *
+ * @property {number} pageSize
+ *   Requested page size. The server can return fewer results than requested.
+ *   If unspecified, the server will pick a default size.
+ *
+ * @property {string} pageToken
+ *   A token identifying a page of results for the server to return.
+ *   Typically obtained from the
+ *   ListTableSpecsResponse.next_page_token field of the previous
+ *   AutoMl.ListTableSpecs call.
+ *
+ * @typedef ListTableSpecsRequest
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.ListTableSpecsRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/service.proto}
+ */
+const ListTableSpecsRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Response message for AutoMl.ListTableSpecs.
+ *
+ * @property {Object[]} tableSpecs
+ *   The table specs read.
+ *
+ *   This object should have the same structure as [TableSpec]{@link google.cloud.automl.v1beta1.TableSpec}
+ *
+ * @property {string} nextPageToken
+ *   A token to retrieve next page of results.
+ *   Pass to ListTableSpecsRequest.page_token to obtain that page.
+ *
+ * @typedef ListTableSpecsResponse
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.ListTableSpecsResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/service.proto}
+ */
+const ListTableSpecsResponse = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Request message for AutoMl.UpdateTableSpec
+ *
+ * @property {Object} tableSpec
+ *   The table spec which replaces the resource on the server.
+ *
+ *   This object should have the same structure as [TableSpec]{@link google.cloud.automl.v1beta1.TableSpec}
+ *
+ * @property {Object} updateMask
+ *   The update mask applies to the resource. For the `FieldMask` definition,
+ *   see
+ *
+ *   https:
+ *   //developers.google.com/protocol-buffers
+ *   // /docs/reference/google.protobuf#fieldmask
+ *
+ *   This object should have the same structure as [FieldMask]{@link google.protobuf.FieldMask}
+ *
+ * @typedef UpdateTableSpecRequest
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.UpdateTableSpecRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/service.proto}
+ */
+const UpdateTableSpecRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Request message for AutoMl.GetColumnSpec.
+ *
+ * @property {string} name
+ *   The resource name of the column spec to retrieve.
+ *
+ * @property {Object} fieldMask
+ *   Mask specifying which fields to read.
+ *
+ *   This object should have the same structure as [FieldMask]{@link google.protobuf.FieldMask}
+ *
+ * @typedef GetColumnSpecRequest
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.GetColumnSpecRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/service.proto}
+ */
+const GetColumnSpecRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Request message for AutoMl.ListColumnSpecs.
+ *
+ * @property {string} parent
+ *   The resource name of the table spec to list column specs from.
+ *
+ * @property {Object} fieldMask
+ *   Mask specifying which fields to read.
+ *
+ *   This object should have the same structure as [FieldMask]{@link google.protobuf.FieldMask}
+ *
+ * @property {string} filter
+ *   Filter expression, see go/filtering.
+ *
+ * @property {number} pageSize
+ *   Requested page size. The server can return fewer results than requested.
+ *   If unspecified, the server will pick a default size.
+ *
+ * @property {string} pageToken
+ *   A token identifying a page of results for the server to return.
+ *   Typically obtained from the
+ *   ListColumnSpecsResponse.next_page_token field of the previous
+ *   AutoMl.ListColumnSpecs call.
+ *
+ * @typedef ListColumnSpecsRequest
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.ListColumnSpecsRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/service.proto}
+ */
+const ListColumnSpecsRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Response message for AutoMl.ListColumnSpecs.
+ *
+ * @property {Object[]} columnSpecs
+ *   The column specs read.
+ *
+ *   This object should have the same structure as [ColumnSpec]{@link google.cloud.automl.v1beta1.ColumnSpec}
+ *
+ * @property {string} nextPageToken
+ *   A token to retrieve next page of results.
+ *   Pass to ListColumnSpecsRequest.page_token to obtain that page.
+ *
+ * @typedef ListColumnSpecsResponse
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.ListColumnSpecsResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/service.proto}
+ */
+const ListColumnSpecsResponse = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Request message for AutoMl.UpdateColumnSpec
+ *
+ * @property {Object} columnSpec
+ *   The column spec which replaces the resource on the server.
+ *
+ *   This object should have the same structure as [ColumnSpec]{@link google.cloud.automl.v1beta1.ColumnSpec}
+ *
+ * @property {Object} updateMask
+ *   The update mask applies to the resource. For the `FieldMask` definition,
+ *   see
+ *
+ *   https:
+ *   //developers.google.com/protocol-buffers
+ *   // /docs/reference/google.protobuf#fieldmask
+ *
+ *   This object should have the same structure as [FieldMask]{@link google.protobuf.FieldMask}
+ *
+ * @typedef UpdateColumnSpecRequest
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.UpdateColumnSpecRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/service.proto}
+ */
+const UpdateColumnSpecRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Request message for AutoMl.CreateModel.
  *
  * @property {string} parent
  *   Resource name of the parent project where the model is being created.
@@ -187,8 +409,7 @@ const CreateModelRequest = {
 };
 
 /**
- * Request message for
- * AutoMl.GetModel.
+ * Request message for AutoMl.GetModel.
  *
  * @property {string} name
  *   Resource name of the model.
@@ -202,8 +423,7 @@ const GetModelRequest = {
 };
 
 /**
- * Request message for
- * AutoMl.ListModels.
+ * Request message for AutoMl.ListModels.
  *
  * @property {string} parent
  *   Resource name of the project, from which to list the models.
@@ -211,15 +431,13 @@ const GetModelRequest = {
  * @property {string} filter
  *   An expression for filtering the results of the request.
  *
- *     * `model_metadata` - for existence of the case.
- *     * `dataset_id` - for = or !=.
- *
- *   Some examples of using the filter are:
+ *     * `model_metadata` - for existence of the case (e.g.
+ *               video_classification_model_metadata:*).
+ *     * `dataset_id` - for = or !=. Some examples of using the filter are:
  *
  *     * `image_classification_model_metadata:*` --> The model has
  *                                          image_classification_model_metadata.
- *     * `dataset_id=5` --> The model was created from a sibling dataset with
- *                      ID 5.
+ *     * `dataset_id=5` --> The model was created from a dataset with ID 5.
  *
  * @property {number} pageSize
  *   Requested page size.
@@ -227,8 +445,7 @@ const GetModelRequest = {
  * @property {string} pageToken
  *   A token identifying a page of results for the server to return
  *   Typically obtained via
- *   ListModelsResponse.next_page_token
- *   of the previous
+ *   ListModelsResponse.next_page_token of the previous
  *   AutoMl.ListModels call.
  *
  * @typedef ListModelsRequest
@@ -240,8 +457,7 @@ const ListModelsRequest = {
 };
 
 /**
- * Response message for
- * AutoMl.ListModels.
+ * Response message for AutoMl.ListModels.
  *
  * @property {Object[]} model
  *   List of models in the requested page.
@@ -250,7 +466,7 @@ const ListModelsRequest = {
  *
  * @property {string} nextPageToken
  *   A token to retrieve next page of results.
- *   Pass to ListModels.page_token to obtain that page.
+ *   Pass to ListModelsRequest.page_token to obtain that page.
  *
  * @typedef ListModelsResponse
  * @memberof google.cloud.automl.v1beta1
@@ -261,8 +477,7 @@ const ListModelsResponse = {
 };
 
 /**
- * Request message for
- * AutoMl.DeleteModel.
+ * Request message for AutoMl.DeleteModel.
  *
  * @property {string} name
  *   Resource name of the model being deleted.
@@ -276,8 +491,12 @@ const DeleteModelRequest = {
 };
 
 /**
- * Request message for
- * AutoMl.DeployModel.
+ * Request message for AutoMl.DeployModel.
+ *
+ * @property {Object} imageObjectDetectionModelDeploymentMetadata
+ *   Model deployment metadata specific to Image Object Detection.
+ *
+ *   This object should have the same structure as [ImageObjectDetectionModelDeploymentMetadata]{@link google.cloud.automl.v1beta1.ImageObjectDetectionModelDeploymentMetadata}
  *
  * @property {string} name
  *   Resource name of the model to deploy.
@@ -291,8 +510,7 @@ const DeployModelRequest = {
 };
 
 /**
- * Request message for
- * AutoMl.UndeployModel.
+ * Request message for AutoMl.UndeployModel.
  *
  * @property {string} name
  *   Resource name of the model to undeploy.
@@ -306,8 +524,48 @@ const UndeployModelRequest = {
 };
 
 /**
- * Request message for
- * AutoMl.GetModelEvaluation.
+ * Request message for AutoMl.ExportModel.
+ * Models need to be enabled for exporting, otherwise an error code will be
+ * returned.
+ *
+ * @property {string} name
+ *   Required. The resource name of the model to export.
+ *
+ * @property {Object} outputConfig
+ *   Required. The desired output location and configuration.
+ *
+ *   This object should have the same structure as [ModelExportOutputConfig]{@link google.cloud.automl.v1beta1.ModelExportOutputConfig}
+ *
+ * @typedef ExportModelRequest
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.ExportModelRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/service.proto}
+ */
+const ExportModelRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Request message for AutoMl.ExportEvaluatedExamples.
+ *
+ * @property {string} name
+ *   Required. The resource name of the model whose evaluated examples are to
+ *   be exported.
+ *
+ * @property {Object} outputConfig
+ *   Required. The desired output location and configuration.
+ *
+ *   This object should have the same structure as [ExportEvaluatedExamplesOutputConfig]{@link google.cloud.automl.v1beta1.ExportEvaluatedExamplesOutputConfig}
+ *
+ * @typedef ExportEvaluatedExamplesRequest
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.ExportEvaluatedExamplesRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/service.proto}
+ */
+const ExportEvaluatedExamplesRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Request message for AutoMl.GetModelEvaluation.
  *
  * @property {string} name
  *   Resource name for the model evaluation.
@@ -321,8 +579,7 @@ const GetModelEvaluationRequest = {
 };
 
 /**
- * Request message for
- * AutoMl.ListModelEvaluations.
+ * Request message for AutoMl.ListModelEvaluations.
  *
  * @property {string} parent
  *   Resource name of the model to list the model evaluations for.
@@ -348,9 +605,8 @@ const GetModelEvaluationRequest = {
  * @property {string} pageToken
  *   A token identifying a page of results for the server to return.
  *   Typically obtained via
- *   `ListModelEvaluationsResponse.next_page_token` of the previous
- *   AutoMl.ListModelEvaluations
- *   call.
+ *   ListModelEvaluationsResponse.next_page_token of the previous
+ *   AutoMl.ListModelEvaluations call.
  *
  * @typedef ListModelEvaluationsRequest
  * @memberof google.cloud.automl.v1beta1
@@ -361,8 +617,7 @@ const ListModelEvaluationsRequest = {
 };
 
 /**
- * Response message for
- * AutoMl.ListModelEvaluations.
+ * Response message for AutoMl.ListModelEvaluations.
  *
  * @property {Object[]} modelEvaluation
  *   List of model evaluations in the requested page.
@@ -371,7 +626,8 @@ const ListModelEvaluationsRequest = {
  *
  * @property {string} nextPageToken
  *   A token to retrieve next page of results.
- *   Pass to ListModelEvaluations.page_token to obtain that page.
+ *   Pass to the ListModelEvaluationsRequest.page_token field of a new
+ *   AutoMl.ListModelEvaluations request to obtain that page.
  *
  * @typedef ListModelEvaluationsResponse
  * @memberof google.cloud.automl.v1beta1

--- a/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_table_spec.js
+++ b/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_table_spec.js
@@ -1,0 +1,68 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
+
+/**
+ * A specification of a relational table.
+ * The table's schema is represented via its child column specs. It is
+ * pre-populated as part of ImportData by schema inference algorithm, the
+ * version of which is a required parameter of ImportData InputConfig.
+ * Note: While working with a table, at times the schema may be
+ * inconsistent with the data in the table (e.g. string in a FLOAT64 column).
+ * The consistency validation is done upon creation of a model.
+ * Used by:
+ *   *   Tables
+ *
+ * @property {string} name
+ *   Output only. The resource name of the table spec.
+ *   Form:
+ *
+ *   `projects/{project_id}/locations/{location_id}/datasets/{dataset_id}/tableSpecs/{table_spec_id}`
+ *
+ * @property {string} timeColumnSpecId
+ *   column_spec_id of the time column. Only used if the parent dataset's
+ *   ml_use_column_spec_id is not set. Used to split rows into TRAIN, VALIDATE
+ *   and TEST sets such that oldest rows go to TRAIN set, newest to TEST, and
+ *   those in between to VALIDATE.
+ *   Required type: TIMESTAMP.
+ *   If both this column and ml_use_column are not set, then ML use of all rows
+ *   will be assigned by AutoML. NOTE: Updates of this field will instantly
+ *   affect any other users concurrently working with the dataset.
+ *
+ * @property {number} rowCount
+ *   Output only. The number of rows (i.e. examples) in the table.
+ *
+ * @property {number} columnCount
+ *   Output only. The number of columns of the table. That is, the number of
+ *   child ColumnSpec-s.
+ *
+ * @property {Object[]} inputConfigs
+ *   Output only. Input configs via which data currently residing in the table
+ *   had been imported.
+ *
+ *   This object should have the same structure as [InputConfig]{@link google.cloud.automl.v1beta1.InputConfig}
+ *
+ * @property {string} etag
+ *   Used to perform consistent read-modify-write updates. If not set, a blind
+ *   "overwrite" update happens.
+ *
+ * @typedef TableSpec
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.TableSpec definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/table_spec.proto}
+ */
+const TableSpec = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};

--- a/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_tables.js
+++ b/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_tables.js
@@ -1,0 +1,282 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
+
+/**
+ * Metadata for a dataset used for AutoML Tables.
+ *
+ * @property {string} primaryTableSpecId
+ *   Output only. The table_spec_id of the primary table of this dataset.
+ *
+ * @property {string} targetColumnSpecId
+ *   column_spec_id of the primary table's column that should be used as the
+ *   training & prediction target.
+ *   This column must be non-nullable and have one of following data types
+ *   (otherwise model creation will error):
+ *   * CATEGORY
+ *   * ARRAY(CATEGORY)
+ *   * FLOAT64
+ *   Furthermore, if the type is CATEGORY or ARRAY(CATEGORY), then only up to
+ *   40 unique values may exist in that column across all rows, but for
+ *   ARRAY(CATEGORY) unique values are counted as elements of the ARRAY (i.e.
+ *   following 3 ARRAY-s: [A, B], [A], [B] are counted as having 2 unique
+ *   values).
+ *
+ *   NOTE: Updates of this field will instantly affect any other users
+ *   concurrently working with the dataset.
+ *
+ * @property {string} weightColumnSpecId
+ *   column_spec_id of the primary table's column that should be used as the
+ *   weight column, i.e. the higher the value the more important the row will be
+ *   during model training.
+ *   Required type: FLOAT64.
+ *   Allowed values: 0 to 10000, inclusive on both ends; 0 means the row is
+ *                   ignored for training.
+ *   If not set all rows are assumed to have equal weight of 1.
+ *   NOTE: Updates of this field will instantly affect any other users
+ *   concurrently working with the dataset.
+ *
+ * @property {string} mlUseColumnSpecId
+ *   column_spec_id of the primary table column which specifies a possible ML
+ *   use of the row, i.e. the column will be used to split the rows into TRAIN,
+ *   VALIDATE and TEST sets.
+ *   Required type: STRING.
+ *   This column, if set, must either have all of `TRAIN`, `VALIDATE`, `TEST`
+ *   among its values, or only have `TEST`, `UNASSIGNED` values. In the latter
+ *   case the rows with `UNASSIGNED` value will be assigned by AutoML. Note
+ *   that if a given ml use distribution makes it impossible to create a "good"
+ *   model, that call will error describing the issue.
+ *   If both this column_spec_id and primary table's time_column_spec_id are not
+ *   set, then all rows are treated as `UNASSIGNED`.
+ *   NOTE: Updates of this field will instantly affect any other users
+ *   concurrently working with the dataset.
+ *
+ * @property {Object.<string, Object>} targetColumnCorrelations
+ *   Output only. Correlations between
+ *
+ *   target_column,
+ *   and other columns of the
+ *
+ *   primary_table.
+ *   Only set if the target column is set. Mapping from other column spec id to
+ *   its CorrelationStats with the target column.
+ *   This field may be stale, see the stats_update_time field for
+ *   for the timestamp at which these stats were last updated.
+ *
+ * @property {Object} statsUpdateTime
+ *   The most recent timestamp when target_column_correlations field and all
+ *   descendant ColumnSpec.data_stats and ColumnSpec.top_correlated_columns
+ *   fields were last (re-)generated. Any changes that happened to the dataset
+ *   afterwards are not reflected in these fields values. The regeneration
+ *   happens in the background on a best effort basis.
+ *
+ *   This object should have the same structure as [Timestamp]{@link google.protobuf.Timestamp}
+ *
+ * @typedef TablesDatasetMetadata
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.TablesDatasetMetadata definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/tables.proto}
+ */
+const TablesDatasetMetadata = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Model metadata specific to AutoML Tables.
+ *
+ * @property {Object} targetColumnSpec
+ *   Column spec of the dataset's primary table's column the model is
+ *   predicting. Snapshotted when model creation started.
+ *   Only 3 fields are used:
+ *   name - May be set on CreateModel, if it's not then the ColumnSpec
+ *          corresponding to the current target_column_spec_id of the dataset
+ *          the model is trained from is used.
+ *          If neither is set, CreateModel will error.
+ *   display_name - Output only.
+ *   data_type - Output only.
+ *
+ *   This object should have the same structure as [ColumnSpec]{@link google.cloud.automl.v1beta1.ColumnSpec}
+ *
+ * @property {Object[]} inputFeatureColumnSpecs
+ *   Column specs of the dataset's primary table's columns, on which
+ *   the model is trained and which are used as the input for predictions.
+ *   The
+ *
+ *   target_column
+ *   as well as, according to dataset's state upon model creation,
+ *
+ *   weight_column,
+ *   and
+ *
+ *   ml_use_column
+ *   must never be included here.
+ *   Only 3 fields are used:
+ *   name - May be set on CreateModel, if set only the columns specified are
+ *          used, otherwise all primary table's columns (except the ones listed
+ *          above) are used for the training and prediction input.
+ *   display_name - Output only.
+ *   data_type - Output only.
+ *
+ *   This object should have the same structure as [ColumnSpec]{@link google.cloud.automl.v1beta1.ColumnSpec}
+ *
+ * @property {string} optimizationObjective
+ *   Objective function the model is optimizing towards. The training process
+ *   creates a model that maximizes/minimizes the value of the objective
+ *   function over the validation set.
+ *
+ *   The supported optimization objectives depend on the prediction_type.
+ *   If the field is not set, a default objective function is used.
+ *
+ *   CLASSIFICATION_BINARY:
+ *     "MAXIMIZE_AU_ROC" (default) - Maximize the area under the receiver
+ *                                   operating characteristic (ROC) curve.
+ *     "MINIMIZE_LOG_LOSS" - Minimize log loss.
+ *     "MAXIMIZE_AU_PRC" - Maximize the area under the precision-recall curve.
+ *
+ *   CLASSIFICATION_MULTI_CLASS :
+ *     "MINIMIZE_LOG_LOSS" (default) - Minimize log loss.
+ *
+ *   CLASSIFICATION_MULTI_LABEL:
+ *     "MINIMIZE_LOG_LOSS" (default) - Minimize log loss.
+ *
+ *   REGRESSION:
+ *     "MINIMIZE_RMSE" (default) - Minimize root-mean-squared error (RMSE).
+ *     "MINIMIZE_MAE" - Minimize mean-absolute error (MAE).
+ *     "MINIMIZE_RMSLE" - Minimize root-mean-squared log error (RMSLE).
+ *
+ *   FORECASTING:
+ *     "MINIMIZE_RMSE" (default) - Minimize root-mean-squared error (RMSE).
+ *     "MINIMIZE_MAE" - Minimize mean-absolute error (MAE).
+ *
+ * @property {Object[]} tablesModelColumnInfo
+ *   Output only. Auxiliary information for each of the
+ *   input_feature_column_specs, with respect to this particular model.
+ *
+ *   This object should have the same structure as [TablesModelColumnInfo]{@link google.cloud.automl.v1beta1.TablesModelColumnInfo}
+ *
+ * @property {number} trainBudgetMilliNodeHours
+ *   The train budget of creating this model, expressed in milli node hours
+ *   i.e. 1,000 value in this field means 1 node hour.
+ *
+ *   The training cost of the model will not exceed this budget. The final cost
+ *   will be attempted to be close to the budget, though may end up being (even)
+ *   noticeably smaller - at the backend's discretion. This especially may
+ *   happen when further model training ceases to provide any improvements.
+ *
+ *   If the budget is set to a value known to be insufficient to train a
+ *   model for the given dataset, the training won't be attempted and
+ *   will error.
+ *
+ * @property {number} trainCostMilliNodeHours
+ *   Output only. The actual training cost of the model, expressed in milli
+ *   node hours, i.e. 1,000 value in this field means 1 node hour. Guaranteed
+ *   to not exceed the train budget.
+ *
+ * @typedef TablesModelMetadata
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.TablesModelMetadata definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/tables.proto}
+ */
+const TablesModelMetadata = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Contains annotation details specific to Tables.
+ *
+ * @property {number} score
+ *   Output only. A confidence estimate between 0.0 and 1.0, inclusive. A higher
+ *   value means greater confidence in the returned value.
+ *   For
+ *
+ *   target_column_spec
+ *   of ARRAY(CATEGORY) data type, this is a confidence that one of the values
+ *   in the ARRAY would be the provided value.
+ *   For
+ *
+ *   target_column_spec
+ *   of FLOAT64 data type the score is not populated.
+ *
+ * @property {Object} predictionInterval
+ *   Output only. Only populated when
+ *
+ *   target_column_spec
+ *   has FLOAT64 data type (i.e. for regression predictions). An interval in
+ *   which the exactly correct target value has 95% chance to be in.
+ *
+ *   This object should have the same structure as [DoubleRange]{@link google.cloud.automl.v1beta1.DoubleRange}
+ *
+ * @property {Object} value
+ *   The predicted value of the row's
+ *
+ *   target_column.
+ *   The value depends on the column's DataType:
+ *   CATEGORY - the predicted (with the above confidence `score`) CATEGORY
+ *              value.
+ *   FLOAT64 - the predicted (with the above confidence `score`) FLOAT64 value.
+ *   ARRAY(CATEGORY) - CATEGORY value meaning that this value would be in the
+ *                     ARRAY in that column (with the above confidence `score`).
+ *
+ *   This object should have the same structure as [Value]{@link google.protobuf.Value}
+ *
+ * @property {Object[]} tablesModelColumnInfo
+ *   Output only. Auxiliary information for each of the model's
+ *
+ *   input_feature_column_specs'
+ *   with respect to this particular prediction.
+ *
+ *   This object should have the same structure as [TablesModelColumnInfo]{@link google.cloud.automl.v1beta1.TablesModelColumnInfo}
+ *
+ * @typedef TablesAnnotation
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.TablesAnnotation definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/tables.proto}
+ */
+const TablesAnnotation = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * An information specific to given column and Tables Model, in context
+ * of the Model and the predictions created by it.
+ *
+ * @property {string} columnSpecName
+ *   Output only. The name of the ColumnSpec describing the column. Not
+ *   populated when this proto is outputted to BigQuery.
+ *
+ * @property {string} columnDisplayName
+ *   Output only. The display name of the column (same as the display_name of
+ *   its ColumnSpec).
+ *
+ * @property {number} featureImportance
+ *   Output only.
+ *
+ *   When given as part of a Model:
+ *   Measurement of how much model predictions correctness on the TEST data
+ *   depend on values in this column. A value between 0 and 1, higher means
+ *   higher influence. These values are normalized - for all input feature
+ *   columns of a given model they add to 1.
+ *
+ *   When given back by Predict or Batch Predict:
+ *   Measurement of how impactful for the prediction returned for the given row
+ *   the value in this column was. A value between 0 and 1, higher means larger
+ *   impact. These values are normalized - for all input feature columns of a
+ *   single predicted row they add to 1.
+ *
+ * @typedef TablesModelColumnInfo
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.TablesModelColumnInfo definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/tables.proto}
+ */
+const TablesModelColumnInfo = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};

--- a/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_temporal.js
+++ b/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_temporal.js
@@ -1,0 +1,39 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
+
+/**
+ * A time period inside of an example that has a time dimension (e.g. video).
+ *
+ * @property {Object} startTimeOffset
+ *   Start of the time segment (inclusive), represented as the duration since
+ *   the example start.
+ *
+ *   This object should have the same structure as [Duration]{@link google.protobuf.Duration}
+ *
+ * @property {Object} endTimeOffset
+ *   End of the time segment (exclusive), represented as the duration since the
+ *   example start.
+ *
+ *   This object should have the same structure as [Duration]{@link google.protobuf.Duration}
+ *
+ * @typedef TimeSegment
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.TimeSegment definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/temporal.proto}
+ */
+const TimeSegment = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};

--- a/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_text.js
+++ b/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_text.js
@@ -41,3 +41,53 @@ const TextClassificationDatasetMetadata = {
 const TextClassificationModelMetadata = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };
+
+/**
+ * Dataset metadata that is specific to text extraction
+ * @typedef TextExtractionDatasetMetadata
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.TextExtractionDatasetMetadata definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/text.proto}
+ */
+const TextExtractionDatasetMetadata = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Model metadata that is specific to text extraction.
+ * @typedef TextExtractionModelMetadata
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.TextExtractionModelMetadata definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/text.proto}
+ */
+const TextExtractionModelMetadata = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Dataset metadata for text sentiment.
+ *
+ * @property {number} sentimentMax
+ *   Required.
+ *   A sentiment is expressed as an integer ordinal, where higher value
+ *   means a more positive sentiment. The range of sentiments that will be used
+ *   is between 0 and sentiment_max (inclusive on both ends), and all the values
+ *   in the range must be represented in the dataset before a model can be
+ *   created.
+ *   sentiment_max value must be between 1 and 10 (inclusive).
+ *
+ * @typedef TextSentimentDatasetMetadata
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.TextSentimentDatasetMetadata definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/text.proto}
+ */
+const TextSentimentDatasetMetadata = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Model metadata that is specific to text classification.
+ * @typedef TextSentimentModelMetadata
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.TextSentimentModelMetadata definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/text.proto}
+ */
+const TextSentimentModelMetadata = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};

--- a/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_text_extraction.js
+++ b/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_text_extraction.js
@@ -1,0 +1,81 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
+
+/**
+ * Annotation for identifying spans of text.
+ *
+ * @property {number} score
+ *   Output only. A confidence estimate between 0.0 and 1.0. A higher value
+ *   means greater confidence in correctness of the annotation.
+ *
+ * @property {Object} textSegment
+ *   Required. The part of the original text to which this annotation pertains.
+ *
+ *   This object should have the same structure as [TextSegment]{@link google.cloud.automl.v1beta1.TextSegment}
+ *
+ * @typedef TextExtractionAnnotation
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.TextExtractionAnnotation definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/text_extraction.proto}
+ */
+const TextExtractionAnnotation = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Model evaluation metrics for text extraction problems.
+ *
+ * @property {number} auPrc
+ *   Output only. The Area under precision recall curve metric.
+ *
+ * @property {Object[]} confidenceMetricsEntries
+ *   Output only. Metrics that have confidence thresholds.
+ *   Precision-recall curve can be derived from it.
+ *
+ *   This object should have the same structure as [ConfidenceMetricsEntry]{@link google.cloud.automl.v1beta1.ConfidenceMetricsEntry}
+ *
+ * @typedef TextExtractionEvaluationMetrics
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.TextExtractionEvaluationMetrics definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/text_extraction.proto}
+ */
+const TextExtractionEvaluationMetrics = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+
+  /**
+   * Metrics for a single confidence threshold.
+   *
+   * @property {number} confidenceThreshold
+   *   Output only. The confidence threshold value used to compute the metrics.
+   *   Only annotations with score of at least this threshold are considered to
+   *   be ones the model would return.
+   *
+   * @property {number} recall
+   *   Output only. Recall under the given confidence threshold.
+   *
+   * @property {number} precision
+   *   Output only. Precision under the given confidence threshold.
+   *
+   * @property {number} f1Score
+   *   Output only. The harmonic mean of recall and precision.
+   *
+   * @typedef ConfidenceMetricsEntry
+   * @memberof google.cloud.automl.v1beta1
+   * @see [google.cloud.automl.v1beta1.TextExtractionEvaluationMetrics.ConfidenceMetricsEntry definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/text_extraction.proto}
+   */
+  ConfidenceMetricsEntry: {
+    // This is for documentation. Actual contents will be loaded by gRPC.
+  }
+};

--- a/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_text_segment.js
+++ b/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_text_segment.js
@@ -1,0 +1,40 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
+
+/**
+ * A contiguous part of a text (string), assuming it has an UTF-8 NFC encoding.
+ * .
+ *
+ * @property {string} content
+ *   Output only. The content of the TextSegment.
+ *
+ * @property {number} startOffset
+ *   Required. Zero-based character index of the first character of the text
+ *   segment (counting characters from the beginning of the text).
+ *
+ * @property {number} endOffset
+ *   Required. Zero-based character index of the first character past the end of
+ *   the text segment (counting character from the beginning of the text).
+ *   The character at the end_offset is NOT included in the text segment.
+ *
+ * @typedef TextSegment
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.TextSegment definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/text_segment.proto}
+ */
+const TextSegment = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};

--- a/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_text_sentiment.js
+++ b/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_text_sentiment.js
@@ -1,0 +1,91 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
+
+/**
+ * Contains annotation details specific to text sentiment.
+ *
+ * @property {number} sentiment
+ *   Output only. The sentiment with the semantic, as given to the
+ *   AutoMl.ImportData when populating the dataset from which the model used
+ *   for the prediction had been trained.
+ *   The sentiment values are between 0 and
+ *   Dataset.text_sentiment_dataset_metadata.sentiment_max (inclusive),
+ *   with higher value meaning more positive sentiment. They are completely
+ *   relative, i.e. 0 means least positive sentiment and sentiment_max means
+ *   the most positive from the sentiments present in the train data. Therefore
+ *    e.g. if train data had only negative sentiment, then sentiment_max, would
+ *   be still negative (although least negative).
+ *   The sentiment shouldn't be confused with "score" or "magnitude"
+ *   from the previous Natural Language Sentiment Analysis API.
+ *
+ * @typedef TextSentimentAnnotation
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.TextSentimentAnnotation definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/text_sentiment.proto}
+ */
+const TextSentimentAnnotation = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Model evaluation metrics for text sentiment problems.
+ *
+ * @property {number} precision
+ *   Output only. Precision.
+ *
+ * @property {number} recall
+ *   Output only. Recall.
+ *
+ * @property {number} f1Score
+ *   Output only. The harmonic mean of recall and precision.
+ *
+ * @property {number} meanAbsoluteError
+ *   Output only. Mean absolute error. Only set for the overall model
+ *   evaluation, not for evaluation of a single annotation spec.
+ *
+ * @property {number} meanSquaredError
+ *   Output only. Mean squared error. Only set for the overall model
+ *   evaluation, not for evaluation of a single annotation spec.
+ *
+ * @property {number} linearKappa
+ *   Output only. Linear weighted kappa. Only set for the overall model
+ *   evaluation, not for evaluation of a single annotation spec.
+ *
+ * @property {number} quadraticKappa
+ *   Output only. Quadratic weighted kappa. Only set for the overall model
+ *   evaluation, not for evaluation of a single annotation spec.
+ *
+ * @property {Object} confusionMatrix
+ *   Output only. Confusion matrix of the evaluation.
+ *   Only set for the overall model evaluation, not for evaluation of a single
+ *   annotation spec.
+ *
+ *   This object should have the same structure as [ConfusionMatrix]{@link google.cloud.automl.v1beta1.ConfusionMatrix}
+ *
+ * @property {string[]} annotationSpecId
+ *   Output only. The annotation spec ids used for this evaluation.
+ *   Deprecated, remove after Boq Migration and use then
+ *   TextSentimentModelMetadata.annotation_spec_count for count, and list
+ *   all model evaluations to see the exact annotation_spec_ids that were
+ *   used.
+ *
+ * @typedef TextSentimentEvaluationMetrics
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.TextSentimentEvaluationMetrics definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/text_sentiment.proto}
+ */
+const TextSentimentEvaluationMetrics = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};

--- a/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_video.js
+++ b/src/v1beta1/doc/google/cloud/automl/v1beta1/doc_video.js
@@ -1,0 +1,37 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
+
+/**
+ * Dataset metadata specific to video classification.
+ * All Video Classification datasets are treated as multi label.
+ * @typedef VideoClassificationDatasetMetadata
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.VideoClassificationDatasetMetadata definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/video.proto}
+ */
+const VideoClassificationDatasetMetadata = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Model metadata specific to video classification.
+ * @typedef VideoClassificationModelMetadata
+ * @memberof google.cloud.automl.v1beta1
+ * @see [google.cloud.automl.v1beta1.VideoClassificationModelMetadata definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/automl/v1beta1/video.proto}
+ */
+const VideoClassificationModelMetadata = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};

--- a/src/v1beta1/doc/google/protobuf/doc_duration.js
+++ b/src/v1beta1/doc/google/protobuf/doc_duration.js
@@ -1,0 +1,97 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
+
+/**
+ * A Duration represents a signed, fixed-length span of time represented
+ * as a count of seconds and fractions of seconds at nanosecond
+ * resolution. It is independent of any calendar and concepts like "day"
+ * or "month". It is related to Timestamp in that the difference between
+ * two Timestamp values is a Duration and it can be added or subtracted
+ * from a Timestamp. Range is approximately +-10,000 years.
+ *
+ * # Examples
+ *
+ * Example 1: Compute Duration from two Timestamps in pseudo code.
+ *
+ *     Timestamp start = ...;
+ *     Timestamp end = ...;
+ *     Duration duration = ...;
+ *
+ *     duration.seconds = end.seconds - start.seconds;
+ *     duration.nanos = end.nanos - start.nanos;
+ *
+ *     if (duration.seconds < 0 && duration.nanos > 0) {
+ *       duration.seconds += 1;
+ *       duration.nanos -= 1000000000;
+ *     } else if (durations.seconds > 0 && duration.nanos < 0) {
+ *       duration.seconds -= 1;
+ *       duration.nanos += 1000000000;
+ *     }
+ *
+ * Example 2: Compute Timestamp from Timestamp + Duration in pseudo code.
+ *
+ *     Timestamp start = ...;
+ *     Duration duration = ...;
+ *     Timestamp end = ...;
+ *
+ *     end.seconds = start.seconds + duration.seconds;
+ *     end.nanos = start.nanos + duration.nanos;
+ *
+ *     if (end.nanos < 0) {
+ *       end.seconds -= 1;
+ *       end.nanos += 1000000000;
+ *     } else if (end.nanos >= 1000000000) {
+ *       end.seconds += 1;
+ *       end.nanos -= 1000000000;
+ *     }
+ *
+ * Example 3: Compute Duration from datetime.timedelta in Python.
+ *
+ *     td = datetime.timedelta(days=3, minutes=10)
+ *     duration = Duration()
+ *     duration.FromTimedelta(td)
+ *
+ * # JSON Mapping
+ *
+ * In JSON format, the Duration type is encoded as a string rather than an
+ * object, where the string ends in the suffix "s" (indicating seconds) and
+ * is preceded by the number of seconds, with nanoseconds expressed as
+ * fractional seconds. For example, 3 seconds with 0 nanoseconds should be
+ * encoded in JSON format as "3s", while 3 seconds and 1 nanosecond should
+ * be expressed in JSON format as "3.000000001s", and 3 seconds and 1
+ * microsecond should be expressed in JSON format as "3.000001s".
+ *
+ * @property {number} seconds
+ *   Signed seconds of the span of time. Must be from -315,576,000,000
+ *   to +315,576,000,000 inclusive. Note: these bounds are computed from:
+ *   60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+ *
+ * @property {number} nanos
+ *   Signed fractions of a second at nanosecond resolution of the span
+ *   of time. Durations less than one second are represented with a 0
+ *   `seconds` field and a positive or negative `nanos` field. For durations
+ *   of one second or more, a non-zero value for the `nanos` field must be
+ *   of the same sign as the `seconds` field. Must be from -999,999,999
+ *   to +999,999,999 inclusive.
+ *
+ * @typedef Duration
+ * @memberof google.protobuf
+ * @see [google.protobuf.Duration definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/duration.proto}
+ */
+const Duration = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};

--- a/src/v1beta1/doc/google/protobuf/doc_field_mask.js
+++ b/src/v1beta1/doc/google/protobuf/doc_field_mask.js
@@ -1,0 +1,236 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
+
+/**
+ * `FieldMask` represents a set of symbolic field paths, for example:
+ *
+ *     paths: "f.a"
+ *     paths: "f.b.d"
+ *
+ * Here `f` represents a field in some root message, `a` and `b`
+ * fields in the message found in `f`, and `d` a field found in the
+ * message in `f.b`.
+ *
+ * Field masks are used to specify a subset of fields that should be
+ * returned by a get operation or modified by an update operation.
+ * Field masks also have a custom JSON encoding (see below).
+ *
+ * # Field Masks in Projections
+ *
+ * When used in the context of a projection, a response message or
+ * sub-message is filtered by the API to only contain those fields as
+ * specified in the mask. For example, if the mask in the previous
+ * example is applied to a response message as follows:
+ *
+ *     f {
+ *       a : 22
+ *       b {
+ *         d : 1
+ *         x : 2
+ *       }
+ *       y : 13
+ *     }
+ *     z: 8
+ *
+ * The result will not contain specific values for fields x,y and z
+ * (their value will be set to the default, and omitted in proto text
+ * output):
+ *
+ *
+ *     f {
+ *       a : 22
+ *       b {
+ *         d : 1
+ *       }
+ *     }
+ *
+ * A repeated field is not allowed except at the last position of a
+ * paths string.
+ *
+ * If a FieldMask object is not present in a get operation, the
+ * operation applies to all fields (as if a FieldMask of all fields
+ * had been specified).
+ *
+ * Note that a field mask does not necessarily apply to the
+ * top-level response message. In case of a REST get operation, the
+ * field mask applies directly to the response, but in case of a REST
+ * list operation, the mask instead applies to each individual message
+ * in the returned resource list. In case of a REST custom method,
+ * other definitions may be used. Where the mask applies will be
+ * clearly documented together with its declaration in the API.  In
+ * any case, the effect on the returned resource/resources is required
+ * behavior for APIs.
+ *
+ * # Field Masks in Update Operations
+ *
+ * A field mask in update operations specifies which fields of the
+ * targeted resource are going to be updated. The API is required
+ * to only change the values of the fields as specified in the mask
+ * and leave the others untouched. If a resource is passed in to
+ * describe the updated values, the API ignores the values of all
+ * fields not covered by the mask.
+ *
+ * If a repeated field is specified for an update operation, the existing
+ * repeated values in the target resource will be overwritten by the new values.
+ * Note that a repeated field is only allowed in the last position of a `paths`
+ * string.
+ *
+ * If a sub-message is specified in the last position of the field mask for an
+ * update operation, then the existing sub-message in the target resource is
+ * overwritten. Given the target message:
+ *
+ *     f {
+ *       b {
+ *         d : 1
+ *         x : 2
+ *       }
+ *       c : 1
+ *     }
+ *
+ * And an update message:
+ *
+ *     f {
+ *       b {
+ *         d : 10
+ *       }
+ *     }
+ *
+ * then if the field mask is:
+ *
+ *  paths: "f.b"
+ *
+ * then the result will be:
+ *
+ *     f {
+ *       b {
+ *         d : 10
+ *       }
+ *       c : 1
+ *     }
+ *
+ * However, if the update mask was:
+ *
+ *  paths: "f.b.d"
+ *
+ * then the result would be:
+ *
+ *     f {
+ *       b {
+ *         d : 10
+ *         x : 2
+ *       }
+ *       c : 1
+ *     }
+ *
+ * In order to reset a field's value to the default, the field must
+ * be in the mask and set to the default value in the provided resource.
+ * Hence, in order to reset all fields of a resource, provide a default
+ * instance of the resource and set all fields in the mask, or do
+ * not provide a mask as described below.
+ *
+ * If a field mask is not present on update, the operation applies to
+ * all fields (as if a field mask of all fields has been specified).
+ * Note that in the presence of schema evolution, this may mean that
+ * fields the client does not know and has therefore not filled into
+ * the request will be reset to their default. If this is unwanted
+ * behavior, a specific service may require a client to always specify
+ * a field mask, producing an error if not.
+ *
+ * As with get operations, the location of the resource which
+ * describes the updated values in the request message depends on the
+ * operation kind. In any case, the effect of the field mask is
+ * required to be honored by the API.
+ *
+ * ## Considerations for HTTP REST
+ *
+ * The HTTP kind of an update operation which uses a field mask must
+ * be set to PATCH instead of PUT in order to satisfy HTTP semantics
+ * (PUT must only be used for full updates).
+ *
+ * # JSON Encoding of Field Masks
+ *
+ * In JSON, a field mask is encoded as a single string where paths are
+ * separated by a comma. Fields name in each path are converted
+ * to/from lower-camel naming conventions.
+ *
+ * As an example, consider the following message declarations:
+ *
+ *     message Profile {
+ *       User user = 1;
+ *       Photo photo = 2;
+ *     }
+ *     message User {
+ *       string display_name = 1;
+ *       string address = 2;
+ *     }
+ *
+ * In proto a field mask for `Profile` may look as such:
+ *
+ *     mask {
+ *       paths: "user.display_name"
+ *       paths: "photo"
+ *     }
+ *
+ * In JSON, the same mask is represented as below:
+ *
+ *     {
+ *       mask: "user.displayName,photo"
+ *     }
+ *
+ * # Field Masks and Oneof Fields
+ *
+ * Field masks treat fields in oneofs just as regular fields. Consider the
+ * following message:
+ *
+ *     message SampleMessage {
+ *       oneof test_oneof {
+ *         string name = 4;
+ *         SubMessage sub_message = 9;
+ *       }
+ *     }
+ *
+ * The field mask can be:
+ *
+ *     mask {
+ *       paths: "name"
+ *     }
+ *
+ * Or:
+ *
+ *     mask {
+ *       paths: "sub_message"
+ *     }
+ *
+ * Note that oneof type names ("test_oneof" in this case) cannot be used in
+ * paths.
+ *
+ * ## Field Mask Verification
+ *
+ * The implementation of any API method which has a FieldMask type field in the
+ * request should verify the included field paths, and return an
+ * `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
+ *
+ * @property {string[]} paths
+ *   The set of field mask paths.
+ *
+ * @typedef FieldMask
+ * @memberof google.protobuf
+ * @see [google.protobuf.FieldMask definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/field_mask.proto}
+ */
+const FieldMask = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};

--- a/src/v1beta1/doc/google/protobuf/doc_struct.js
+++ b/src/v1beta1/doc/google/protobuf/doc_struct.js
@@ -1,0 +1,112 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
+
+/**
+ * `Struct` represents a structured data value, consisting of fields
+ * which map to dynamically typed values. In some languages, `Struct`
+ * might be supported by a native representation. For example, in
+ * scripting languages like JS a struct is represented as an
+ * object. The details of that representation are described together
+ * with the proto support for the language.
+ *
+ * The JSON representation for `Struct` is JSON object.
+ *
+ * @property {Object.<string, Object>} fields
+ *   Unordered map of dynamically typed values.
+ *
+ * @typedef Struct
+ * @memberof google.protobuf
+ * @see [google.protobuf.Struct definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/struct.proto}
+ */
+const Struct = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * `Value` represents a dynamically typed value which can be either
+ * null, a number, a string, a boolean, a recursive struct value, or a
+ * list of values. A producer of value is expected to set one of that
+ * variants, absence of any variant indicates an error.
+ *
+ * The JSON representation for `Value` is JSON value.
+ *
+ * @property {number} nullValue
+ *   Represents a null value.
+ *
+ *   The number should be among the values of [NullValue]{@link google.protobuf.NullValue}
+ *
+ * @property {number} numberValue
+ *   Represents a double value.
+ *
+ * @property {string} stringValue
+ *   Represents a string value.
+ *
+ * @property {boolean} boolValue
+ *   Represents a boolean value.
+ *
+ * @property {Object} structValue
+ *   Represents a structured value.
+ *
+ *   This object should have the same structure as [Struct]{@link google.protobuf.Struct}
+ *
+ * @property {Object} listValue
+ *   Represents a repeated `Value`.
+ *
+ *   This object should have the same structure as [ListValue]{@link google.protobuf.ListValue}
+ *
+ * @typedef Value
+ * @memberof google.protobuf
+ * @see [google.protobuf.Value definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/struct.proto}
+ */
+const Value = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * `ListValue` is a wrapper around a repeated field of values.
+ *
+ * The JSON representation for `ListValue` is JSON array.
+ *
+ * @property {Object[]} values
+ *   Repeated field of dynamically typed values.
+ *
+ *   This object should have the same structure as [Value]{@link google.protobuf.Value}
+ *
+ * @typedef ListValue
+ * @memberof google.protobuf
+ * @see [google.protobuf.ListValue definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/struct.proto}
+ */
+const ListValue = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * `NullValue` is a singleton enumeration to represent the null value for the
+ * `Value` type union.
+ *
+ *  The JSON representation for `NullValue` is JSON `null`.
+ *
+ * @enum {number}
+ * @memberof google.protobuf
+ */
+const NullValue = {
+
+  /**
+   * Null value.
+   */
+  NULL_VALUE: 0
+};

--- a/src/v1beta1/prediction_service_client_config.json
+++ b/src/v1beta1/prediction_service_client_config.json
@@ -24,6 +24,11 @@
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
+        },
+        "BatchPredict": {
+          "timeout_millis": 20000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
         }
       }
     }

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-03-28T11:25:30.156871Z",
+  "updateTime": "2019-04-02T22:19:21.487019Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.16.20",
-        "dockerImage": "googleapis/artman@sha256:e3c054a2fb85a12481c722af616c7fb6f1d02d862248385eecbec3e4240ebd1e"
+        "version": "0.16.22",
+        "dockerImage": "googleapis/artman@sha256:e7f9554322a8aa1416c122c918fdc4cdec8cfe816f027fc948dec0be7edef320"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "6a84b3267b0a95e922608b9891219075047eee29",
-        "internalRef": "240640999"
+        "sha": "ca5ac18934ca57b49301e3a754ed8e0e4f4cd2de",
+        "internalRef": "241613588"
       }
     },
     {

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-04-02T22:19:21.487019Z",
+  "updateTime": "2019-04-03T18:07:05.400451Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.16.22",
-        "dockerImage": "googleapis/artman@sha256:e7f9554322a8aa1416c122c918fdc4cdec8cfe816f027fc948dec0be7edef320"
+        "version": "0.16.23",
+        "dockerImage": "googleapis/artman@sha256:f3a3f88000dc1cd1b4826104c5574aa5c534f6793fbf66e888d11c0d7ef5762e"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "ca5ac18934ca57b49301e3a754ed8e0e4f4cd2de",
-        "internalRef": "241613588"
+        "sha": "233e53488c497e6e3aba6ff9b7f14b9839128451",
+        "internalRef": "241760062"
       }
     },
     {

--- a/synth.py
+++ b/synth.py
@@ -39,11 +39,6 @@ s.replace('**/doc/google/protobuf/doc_timestamp.js',
         'toISOString)')
 # [END fix-dead-link]
 
-s.replace('src/v1beta1/doc/google/cloud/automl/v1beta1/doc_io.js',
-        'https:[\s\*]+//cloud\.google\.com\/vision\/automl\/alpha\/d[\s\*\/]+ocs\/predict#deployment_to_devices',
-        'https://cloud.google.com/vision/automl/alpha/docs/predict#deployment_to_devices')
-
-
 # Node.js specific cleanup
 subprocess.run(['npm', 'install'])
 subprocess.run(['npm', 'run', 'fix'])

--- a/synth.py
+++ b/synth.py
@@ -39,6 +39,10 @@ s.replace('**/doc/google/protobuf/doc_timestamp.js',
         'toISOString)')
 # [END fix-dead-link]
 
+s.replace('src/v1beta1/doc/google/cloud/automl/v1beta1/doc_io.js',
+        'https:[\s\*]+//cloud\.google\.com\/vision\/automl\/alpha\/d[\s\*\/]+ocs\/predict#deployment_to_devices',
+        'https://cloud.google.com/vision/automl/alpha/docs/predict#deployment_to_devices')
+
 
 # Node.js specific cleanup
 subprocess.run(['npm', 'install'])

--- a/test/gapic-v1beta1.js
+++ b/test/gapic-v1beta1.js
@@ -41,11 +41,15 @@ describe('AutoMlClient', () => {
       // Mock response
       const name = 'name3373707';
       const displayName = 'displayName1615086568';
+      const description = 'description-1724546052';
       const exampleCount = 1517063674;
+      const etag = 'etag3123477';
       const expectedResponse = {
         name: name,
         displayName: displayName,
+        description: description,
         exampleCount: exampleCount,
+        etag: etag,
       };
 
       // Mock Grpc layer
@@ -91,6 +95,74 @@ describe('AutoMlClient', () => {
     });
   });
 
+  describe('updateDataset', () => {
+    it('invokes updateDataset without error', done => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const dataset = {};
+      const request = {
+        dataset: dataset,
+      };
+
+      // Mock response
+      const name = 'name3373707';
+      const displayName = 'displayName1615086568';
+      const description = 'description-1724546052';
+      const exampleCount = 1517063674;
+      const etag = 'etag3123477';
+      const expectedResponse = {
+        name: name,
+        displayName: displayName,
+        description: description,
+        exampleCount: exampleCount,
+        etag: etag,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.updateDataset = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.updateDataset(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes updateDataset with error', done => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const dataset = {};
+      const request = {
+        dataset: dataset,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.updateDataset = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.updateDataset(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
   describe('getDataset', () => {
     it('invokes getDataset without error', done => {
       const client = new automlModule.v1beta1.AutoMlClient({
@@ -111,11 +183,15 @@ describe('AutoMlClient', () => {
       // Mock response
       const name2 = 'name2-1052831874';
       const displayName = 'displayName1615086568';
+      const description = 'description-1724546052';
       const exampleCount = 1517063674;
+      const etag = 'etag3123477';
       const expectedResponse = {
         name: name2,
         displayName: displayName,
+        description: description,
         exampleCount: exampleCount,
+        etag: etag,
       };
 
       // Mock Grpc layer
@@ -856,7 +932,7 @@ describe('AutoMlClient', () => {
     });
   });
 
-  describe('deployModel', () => {
+  describe('deployModel', function() {
     it('invokes deployModel without error', done => {
       const client = new automlModule.v1beta1.AutoMlClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
@@ -874,24 +950,27 @@ describe('AutoMlClient', () => {
       };
 
       // Mock response
-      const name2 = 'name2-1052831874';
-      const done_ = true;
-      const expectedResponse = {
-        name: name2,
-        done: done_,
-      };
+      const expectedResponse = {};
 
       // Mock Grpc layer
-      client._innerApiCalls.deployModel = mockSimpleGrpcMethod(
+      client._innerApiCalls.deployModel = mockLongRunningGrpcMethod(
         request,
         expectedResponse
       );
 
-      client.deployModel(request, (err, response) => {
-        assert.ifError(err);
-        assert.deepStrictEqual(response, expectedResponse);
-        done();
-      });
+      client
+        .deployModel(request)
+        .then(responses => {
+          const operation = responses[0];
+          return operation.promise();
+        })
+        .then(responses => {
+          assert.deepStrictEqual(responses[0], expectedResponse);
+          done();
+        })
+        .catch(err => {
+          done(err);
+        });
     });
 
     it('invokes deployModel with error', done => {
@@ -911,22 +990,45 @@ describe('AutoMlClient', () => {
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.deployModel = mockSimpleGrpcMethod(
+      client._innerApiCalls.deployModel = mockLongRunningGrpcMethod(
         request,
         null,
         error
       );
 
-      client.deployModel(request, (err, response) => {
-        assert(err instanceof Error);
-        assert.strictEqual(err.code, FAKE_STATUS_CODE);
-        assert(typeof response === 'undefined');
-        done();
+      client
+        .deployModel(request)
+        .then(responses => {
+          const operation = responses[0];
+          return operation.promise();
+        })
+        .then(() => {
+          assert.fail();
+        })
+        .catch(err => {
+          assert(err instanceof Error);
+          assert.strictEqual(err.code, FAKE_STATUS_CODE);
+          done();
+        });
+    });
+
+    it('has longrunning decoder functions', () => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
       });
+      assert(
+        client._descriptors.longrunning.deployModel.responseDecoder instanceof
+          Function
+      );
+      assert(
+        client._descriptors.longrunning.deployModel.metadataDecoder instanceof
+          Function
+      );
     });
   });
 
-  describe('undeployModel', () => {
+  describe('undeployModel', function() {
     it('invokes undeployModel without error', done => {
       const client = new automlModule.v1beta1.AutoMlClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
@@ -944,24 +1046,27 @@ describe('AutoMlClient', () => {
       };
 
       // Mock response
-      const name2 = 'name2-1052831874';
-      const done_ = true;
-      const expectedResponse = {
-        name: name2,
-        done: done_,
-      };
+      const expectedResponse = {};
 
       // Mock Grpc layer
-      client._innerApiCalls.undeployModel = mockSimpleGrpcMethod(
+      client._innerApiCalls.undeployModel = mockLongRunningGrpcMethod(
         request,
         expectedResponse
       );
 
-      client.undeployModel(request, (err, response) => {
-        assert.ifError(err);
-        assert.deepStrictEqual(response, expectedResponse);
-        done();
-      });
+      client
+        .undeployModel(request)
+        .then(responses => {
+          const operation = responses[0];
+          return operation.promise();
+        })
+        .then(responses => {
+          assert.deepStrictEqual(responses[0], expectedResponse);
+          done();
+        })
+        .catch(err => {
+          done(err);
+        });
     });
 
     it('invokes undeployModel with error', done => {
@@ -981,18 +1086,41 @@ describe('AutoMlClient', () => {
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.undeployModel = mockSimpleGrpcMethod(
+      client._innerApiCalls.undeployModel = mockLongRunningGrpcMethod(
         request,
         null,
         error
       );
 
-      client.undeployModel(request, (err, response) => {
-        assert(err instanceof Error);
-        assert.strictEqual(err.code, FAKE_STATUS_CODE);
-        assert(typeof response === 'undefined');
-        done();
+      client
+        .undeployModel(request)
+        .then(responses => {
+          const operation = responses[0];
+          return operation.promise();
+        })
+        .then(() => {
+          assert.fail();
+        })
+        .catch(err => {
+          assert(err instanceof Error);
+          assert.strictEqual(err.code, FAKE_STATUS_CODE);
+          done();
+        });
+    });
+
+    it('has longrunning decoder functions', () => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
       });
+      assert(
+        client._descriptors.longrunning.undeployModel.responseDecoder instanceof
+          Function
+      );
+      assert(
+        client._descriptors.longrunning.undeployModel.metadataDecoder instanceof
+          Function
+      );
     });
   });
 
@@ -1017,10 +1145,12 @@ describe('AutoMlClient', () => {
       // Mock response
       const name2 = 'name2-1052831874';
       const annotationSpecId = 'annotationSpecId60690191';
+      const displayName = 'displayName1615086568';
       const evaluatedExampleCount = 277565350;
       const expectedResponse = {
         name: name2,
         annotationSpecId: annotationSpecId,
+        displayName: displayName,
         evaluatedExampleCount: evaluatedExampleCount,
       };
 
@@ -1067,6 +1197,206 @@ describe('AutoMlClient', () => {
         assert(typeof response === 'undefined');
         done();
       });
+    });
+  });
+
+  describe('exportModel', function() {
+    it('invokes exportModel without error', done => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const formattedName = client.modelPath(
+        '[PROJECT]',
+        '[LOCATION]',
+        '[MODEL]'
+      );
+      const outputConfig = {};
+      const request = {
+        name: formattedName,
+        outputConfig: outputConfig,
+      };
+
+      // Mock response
+      const expectedResponse = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.exportModel = mockLongRunningGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client
+        .exportModel(request)
+        .then(responses => {
+          const operation = responses[0];
+          return operation.promise();
+        })
+        .then(responses => {
+          assert.deepStrictEqual(responses[0], expectedResponse);
+          done();
+        })
+        .catch(err => {
+          done(err);
+        });
+    });
+
+    it('invokes exportModel with error', done => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const formattedName = client.modelPath(
+        '[PROJECT]',
+        '[LOCATION]',
+        '[MODEL]'
+      );
+      const outputConfig = {};
+      const request = {
+        name: formattedName,
+        outputConfig: outputConfig,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.exportModel = mockLongRunningGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client
+        .exportModel(request)
+        .then(responses => {
+          const operation = responses[0];
+          return operation.promise();
+        })
+        .then(() => {
+          assert.fail();
+        })
+        .catch(err => {
+          assert(err instanceof Error);
+          assert.strictEqual(err.code, FAKE_STATUS_CODE);
+          done();
+        });
+    });
+
+    it('has longrunning decoder functions', () => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      assert(
+        client._descriptors.longrunning.exportModel.responseDecoder instanceof
+          Function
+      );
+      assert(
+        client._descriptors.longrunning.exportModel.metadataDecoder instanceof
+          Function
+      );
+    });
+  });
+
+  describe('exportEvaluatedExamples', function() {
+    it('invokes exportEvaluatedExamples without error', done => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const formattedName = client.modelPath(
+        '[PROJECT]',
+        '[LOCATION]',
+        '[MODEL]'
+      );
+      const outputConfig = {};
+      const request = {
+        name: formattedName,
+        outputConfig: outputConfig,
+      };
+
+      // Mock response
+      const expectedResponse = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.exportEvaluatedExamples = mockLongRunningGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client
+        .exportEvaluatedExamples(request)
+        .then(responses => {
+          const operation = responses[0];
+          return operation.promise();
+        })
+        .then(responses => {
+          assert.deepStrictEqual(responses[0], expectedResponse);
+          done();
+        })
+        .catch(err => {
+          done(err);
+        });
+    });
+
+    it('invokes exportEvaluatedExamples with error', done => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const formattedName = client.modelPath(
+        '[PROJECT]',
+        '[LOCATION]',
+        '[MODEL]'
+      );
+      const outputConfig = {};
+      const request = {
+        name: formattedName,
+        outputConfig: outputConfig,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.exportEvaluatedExamples = mockLongRunningGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client
+        .exportEvaluatedExamples(request)
+        .then(responses => {
+          const operation = responses[0];
+          return operation.promise();
+        })
+        .then(() => {
+          assert.fail();
+        })
+        .catch(err => {
+          assert(err instanceof Error);
+          assert.strictEqual(err.code, FAKE_STATUS_CODE);
+          done();
+        });
+    });
+
+    it('has longrunning decoder functions', () => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      assert(
+        client._descriptors.longrunning.exportEvaluatedExamples
+          .responseDecoder instanceof Function
+      );
+      assert(
+        client._descriptors.longrunning.exportEvaluatedExamples
+          .metadataDecoder instanceof Function
+      );
     });
   });
 
@@ -1144,6 +1474,518 @@ describe('AutoMlClient', () => {
       });
     });
   });
+
+  describe('getAnnotationSpec', () => {
+    it('invokes getAnnotationSpec without error', done => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const formattedName = client.annotationSpecPath(
+        '[PROJECT]',
+        '[LOCATION]',
+        '[DATASET]',
+        '[ANNOTATION_SPEC]'
+      );
+      const request = {
+        name: formattedName,
+      };
+
+      // Mock response
+      const name2 = 'name2-1052831874';
+      const displayName = 'displayName1615086568';
+      const exampleCount = 1517063674;
+      const expectedResponse = {
+        name: name2,
+        displayName: displayName,
+        exampleCount: exampleCount,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.getAnnotationSpec = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.getAnnotationSpec(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes getAnnotationSpec with error', done => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const formattedName = client.annotationSpecPath(
+        '[PROJECT]',
+        '[LOCATION]',
+        '[DATASET]',
+        '[ANNOTATION_SPEC]'
+      );
+      const request = {
+        name: formattedName,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.getAnnotationSpec = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.getAnnotationSpec(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('getTableSpec', () => {
+    it('invokes getTableSpec without error', done => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const formattedName = client.tableSpecPath(
+        '[PROJECT]',
+        '[LOCATION]',
+        '[DATASET]',
+        '[TABLE_SPEC]'
+      );
+      const request = {
+        name: formattedName,
+      };
+
+      // Mock response
+      const name2 = 'name2-1052831874';
+      const timeColumnSpecId = 'timeColumnSpecId1558734824';
+      const rowCount = 1340416618;
+      const columnCount = 122671386;
+      const etag = 'etag3123477';
+      const expectedResponse = {
+        name: name2,
+        timeColumnSpecId: timeColumnSpecId,
+        rowCount: rowCount,
+        columnCount: columnCount,
+        etag: etag,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.getTableSpec = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.getTableSpec(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes getTableSpec with error', done => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const formattedName = client.tableSpecPath(
+        '[PROJECT]',
+        '[LOCATION]',
+        '[DATASET]',
+        '[TABLE_SPEC]'
+      );
+      const request = {
+        name: formattedName,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.getTableSpec = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.getTableSpec(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('listTableSpecs', () => {
+    it('invokes listTableSpecs without error', done => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const formattedParent = client.datasetPath(
+        '[PROJECT]',
+        '[LOCATION]',
+        '[DATASET]'
+      );
+      const request = {
+        parent: formattedParent,
+      };
+
+      // Mock response
+      const nextPageToken = '';
+      const tableSpecsElement = {};
+      const tableSpecs = [tableSpecsElement];
+      const expectedResponse = {
+        nextPageToken: nextPageToken,
+        tableSpecs: tableSpecs,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.listTableSpecs = (
+        actualRequest,
+        options,
+        callback
+      ) => {
+        assert.deepStrictEqual(actualRequest, request);
+        callback(null, expectedResponse.tableSpecs);
+      };
+
+      client.listTableSpecs(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse.tableSpecs);
+        done();
+      });
+    });
+
+    it('invokes listTableSpecs with error', done => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const formattedParent = client.datasetPath(
+        '[PROJECT]',
+        '[LOCATION]',
+        '[DATASET]'
+      );
+      const request = {
+        parent: formattedParent,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.listTableSpecs = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.listTableSpecs(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('updateTableSpec', () => {
+    it('invokes updateTableSpec without error', done => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const tableSpec = {};
+      const request = {
+        tableSpec: tableSpec,
+      };
+
+      // Mock response
+      const name = 'name3373707';
+      const timeColumnSpecId = 'timeColumnSpecId1558734824';
+      const rowCount = 1340416618;
+      const columnCount = 122671386;
+      const etag = 'etag3123477';
+      const expectedResponse = {
+        name: name,
+        timeColumnSpecId: timeColumnSpecId,
+        rowCount: rowCount,
+        columnCount: columnCount,
+        etag: etag,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.updateTableSpec = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.updateTableSpec(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes updateTableSpec with error', done => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const tableSpec = {};
+      const request = {
+        tableSpec: tableSpec,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.updateTableSpec = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.updateTableSpec(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('getColumnSpec', () => {
+    it('invokes getColumnSpec without error', done => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const formattedName = client.columnSpecPath(
+        '[PROJECT]',
+        '[LOCATION]',
+        '[DATASET]',
+        '[TABLE_SPEC]',
+        '[COLUMN_SPEC]'
+      );
+      const request = {
+        name: formattedName,
+      };
+
+      // Mock response
+      const name2 = 'name2-1052831874';
+      const displayName = 'displayName1615086568';
+      const etag = 'etag3123477';
+      const expectedResponse = {
+        name: name2,
+        displayName: displayName,
+        etag: etag,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.getColumnSpec = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.getColumnSpec(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes getColumnSpec with error', done => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const formattedName = client.columnSpecPath(
+        '[PROJECT]',
+        '[LOCATION]',
+        '[DATASET]',
+        '[TABLE_SPEC]',
+        '[COLUMN_SPEC]'
+      );
+      const request = {
+        name: formattedName,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.getColumnSpec = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.getColumnSpec(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('listColumnSpecs', () => {
+    it('invokes listColumnSpecs without error', done => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const formattedParent = client.tableSpecPath(
+        '[PROJECT]',
+        '[LOCATION]',
+        '[DATASET]',
+        '[TABLE_SPEC]'
+      );
+      const request = {
+        parent: formattedParent,
+      };
+
+      // Mock response
+      const nextPageToken = '';
+      const columnSpecsElement = {};
+      const columnSpecs = [columnSpecsElement];
+      const expectedResponse = {
+        nextPageToken: nextPageToken,
+        columnSpecs: columnSpecs,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.listColumnSpecs = (
+        actualRequest,
+        options,
+        callback
+      ) => {
+        assert.deepStrictEqual(actualRequest, request);
+        callback(null, expectedResponse.columnSpecs);
+      };
+
+      client.listColumnSpecs(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse.columnSpecs);
+        done();
+      });
+    });
+
+    it('invokes listColumnSpecs with error', done => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const formattedParent = client.tableSpecPath(
+        '[PROJECT]',
+        '[LOCATION]',
+        '[DATASET]',
+        '[TABLE_SPEC]'
+      );
+      const request = {
+        parent: formattedParent,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.listColumnSpecs = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.listColumnSpecs(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('updateColumnSpec', () => {
+    it('invokes updateColumnSpec without error', done => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const columnSpec = {};
+      const request = {
+        columnSpec: columnSpec,
+      };
+
+      // Mock response
+      const name = 'name3373707';
+      const displayName = 'displayName1615086568';
+      const etag = 'etag3123477';
+      const expectedResponse = {
+        name: name,
+        displayName: displayName,
+        etag: etag,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.updateColumnSpec = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.updateColumnSpec(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes updateColumnSpec with error', done => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const columnSpec = {};
+      const request = {
+        columnSpec: columnSpec,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.updateColumnSpec = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.updateColumnSpec(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
 });
 describe('PredictionServiceClient', () => {
   describe('predict', () => {
@@ -1212,6 +2054,110 @@ describe('PredictionServiceClient', () => {
         assert(typeof response === 'undefined');
         done();
       });
+    });
+  });
+
+  describe('batchPredict', function() {
+    it('invokes batchPredict without error', done => {
+      const client = new automlModule.v1beta1.PredictionServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const formattedName = client.modelPath(
+        '[PROJECT]',
+        '[LOCATION]',
+        '[MODEL]'
+      );
+      const inputConfig = {};
+      const outputConfig = {};
+      const request = {
+        name: formattedName,
+        inputConfig: inputConfig,
+        outputConfig: outputConfig,
+      };
+
+      // Mock response
+      const expectedResponse = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.batchPredict = mockLongRunningGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client
+        .batchPredict(request)
+        .then(responses => {
+          const operation = responses[0];
+          return operation.promise();
+        })
+        .then(responses => {
+          assert.deepStrictEqual(responses[0], expectedResponse);
+          done();
+        })
+        .catch(err => {
+          done(err);
+        });
+    });
+
+    it('invokes batchPredict with error', done => {
+      const client = new automlModule.v1beta1.PredictionServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const formattedName = client.modelPath(
+        '[PROJECT]',
+        '[LOCATION]',
+        '[MODEL]'
+      );
+      const inputConfig = {};
+      const outputConfig = {};
+      const request = {
+        name: formattedName,
+        inputConfig: inputConfig,
+        outputConfig: outputConfig,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.batchPredict = mockLongRunningGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client
+        .batchPredict(request)
+        .then(responses => {
+          const operation = responses[0];
+          return operation.promise();
+        })
+        .then(() => {
+          assert.fail();
+        })
+        .catch(err => {
+          assert(err instanceof Error);
+          assert.strictEqual(err.code, FAKE_STATUS_CODE);
+          done();
+        });
+    });
+
+    it('has longrunning decoder functions', () => {
+      const client = new automlModule.v1beta1.PredictionServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      assert(
+        client._descriptors.longrunning.batchPredict.responseDecoder instanceof
+          Function
+      );
+      assert(
+        client._descriptors.longrunning.batchPredict.metadataDecoder instanceof
+          Function
+      );
     });
   });
 });


### PR DESCRIPTION
This captures the following changes:

- \+ these AutoML problem variants, and supporting fields to build and predict with these models:
   - Image object detection
   - Video classification
   - Text extraction
   - Text sentiment
   - Tables
- \+ `batchPredict` method to perform batch prediction (long running operation).
- \+ new response metadata to show model evaluation metrics, e.g. RMS error, MAE, R-squared
- \+ `updateDataset` method to perform updates to a dataset after it's been created
- \+ methods to get/update/list specs for a relational table:
    - `getAnnotationSpec`, `getTableSpec`, `listTableSpecs`, `updateTableSpec`, `getColumnSpec`, `listColumnSpecs`, `updateColumnSpec`
- \+ `exportModel` method to export a trained, export-able model to a GCS location
- \+ `exportEvaluatedExamples` method to export examples on which the models was evaluated