### PR TITLE
docs(samples): fixed comment typo

### DIFF
--- a/samples/vision/automlVisionPredict.js
+++ b/samples/vision/automlVisionPredict.js
@@ -44,7 +44,7 @@ async function predict(
   // const computeRegion = `region-name, e.g. "us-central1"`;
   // const modelId = `id of the model, e.g. “ICN12345”`;
   // const filePath = `local text file path of content to be classified, e.g. "./resources/test.txt"`;
-  // const scoreThreshold = `value between 0.0 and 1.0, e.g. "0.5"';
+  // const scoreThreshold = `value between 0.0 and 1.0, e.g. "0.5"`;
 
   // Get the full path of the model.
   const modelFullId = client.modelPath(projectId, computeRegion, modelId);


### PR DESCRIPTION
Noticed the grave accent being used to open the line and an apostrophe being used to close the line. Updated it to have a grave accent like every other line in the TODO section of the file. 

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
