### PR TITLE
feat: add .repo-metadata.json; allows us to generate new docs site

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -3,7 +3,7 @@
   "name_pretty": "Cloud AutoML",
   "product_documentation": "https://cloud.google.com/automl/docs/",
   "client_documentation": "https://cloud.google.com/nodejs/docs/reference/automl/latest/",
-  "issue_tracker": "",
+  "issue_tracker": "https://issuetracker.google.com/savedsearches/559744",
   "release_level": "beta",
   "language": "nodejs",
   "repo": "googleapis/nodejs-automl",

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,0 +1,13 @@
+{
+  "name": "automl",
+  "name_pretty": "Cloud AutoML",
+  "product_documentation": "https://cloud.google.com/automl/docs/",
+  "client_documentation": "https://cloud.google.com/nodejs/docs/reference/automl/latest/",
+  "issue_tracker": "",
+  "release_level": "beta",
+  "language": "nodejs",
+  "repo": "googleapis/nodejs-automl",
+  "distribution_name": "@google-cloud/automl",
+  "api_id": "automl.googleapis.com",
+  "requires_billing": true
+}

--- a/README.md
+++ b/README.md
@@ -55,13 +55,6 @@ npm install @google-cloud/automl
 ### Using the client library
 
 ```javascript
-async function main(
-  projectId,
-  computeRegion,
-  modelId,
-  filePath,
-  scoreThreshold
-) {
   const automl = require('@google-cloud/automl');
   const fs = require('fs');
 
@@ -105,7 +98,6 @@ async function main(
     console.log(`Predicted class name: ${result.displayName}`);
     console.log(`Predicted class score: ${result.classification.score}`);
   });
-}
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,53 +1,143 @@
 [//]: # "This README.md file is auto-generated, all changes to this file will be lost."
-[//]: # "To regenerate it, use `npm run generate-scaffolding`."
+[//]: # "To regenerate it, use `python -m synthtool`."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
 # [Cloud AutoML: Node.js Client](https://github.com/googleapis/nodejs-automl)
 
-[![release level](https://img.shields.io/badge/release%20level-alpha-orange.svg?style&#x3D;flat)](https://cloud.google.com/terms/launch-stages)
+[![release level](https://img.shields.io/badge/release%20level-beta-yellow.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
 [![npm version](https://img.shields.io/npm/v/@google-cloud/automl.svg)](https://www.npmjs.org/package/@google-cloud/automl)
 [![codecov](https://img.shields.io/codecov/c/github/googleapis/nodejs-automl/master.svg?style=flat)](https://codecov.io/gh/googleapis/nodejs-automl)
 
-Train high quality custom machine learning models with minimum effort and machine learning expertise
 
 
-* [Using the client library](#using-the-client-library)
+
+Cloud AutoML API client for Node.js
+
+
+* [Cloud AutoML Node.js Client API Reference][client-docs]
+* [Cloud AutoML Documentation][product-docs]
+* [github.com/googleapis/nodejs-automl](https://github.com/googleapis/nodejs-automl)
+
+Read more about the client libraries for Cloud APIs, including the older
+Google APIs Client Libraries, in [Client Libraries Explained][explained].
+
+[explained]: https://cloud.google.com/apis/docs/client-libraries-explained
+
+**Table of contents:**
+
+
+* [Quickstart](#quickstart)
+  * [Before you begin](#before-you-begin)
+  * [Installing the client library](#installing-the-client-library)
+  * [Using the client library](#using-the-client-library)
+* [Samples](#samples)
 * [Versioning](#versioning)
 * [Contributing](#contributing)
 * [License](#license)
 
-## Using the client library
+## Quickstart
+
+### Before you begin
 
 1.  [Select or create a Cloud Platform project][projects].
-
 1.  [Enable billing for your project][billing].
-
 1.  [Enable the Cloud AutoML API][enable_api].
-
 1.  [Set up authentication with a service account][auth] so you can access the
     API from your local workstation.
 
-1. Install the client library:
+### Installing the client library
 
-        npm install --save @google-cloud/automl
-
-1. Try an example:
-
-```javascript
-// TBD
+```bash
+npm install @google-cloud/automl
 ```
 
 
-The [AutoML Node.js Client API Reference][client-docs] documentation
+### Using the client library
+
+```javascript
+async function main(
+  projectId,
+  computeRegion,
+  modelId,
+  filePath,
+  scoreThreshold
+) {
+  const automl = require('@google-cloud/automl');
+  const fs = require('fs');
+
+  // Create client for prediction service.
+  const client = new automl.PredictionServiceClient();
+
+  /**
+   * TODO(developer): Uncomment the following line before running the sample.
+   */
+  // const projectId = `The GCLOUD_PROJECT string, e.g. "my-gcloud-project"`;
+  // const computeRegion = `region-name, e.g. "us-central1"`;
+  // const modelId = `id of the model, e.g. “ICN723541179344731436”`;
+  // const filePath = `local text file path of content to be classified, e.g. "./resources/flower.png"`;
+  // const scoreThreshold = `value between 0.0 and 1.0, e.g. "0.5"`;
+
+  // Get the full path of the model.
+  const modelFullId = client.modelPath(projectId, computeRegion, modelId);
+
+  // Read the file content for prediction.
+  const content = fs.readFileSync(filePath, 'base64');
+
+  const params = {};
+
+  if (scoreThreshold) {
+    params.score_threshold = scoreThreshold;
+  }
+
+  // Set the payload by giving the content and type of the file.
+  const payload = {};
+  payload.image = {imageBytes: content};
+
+  // params is additional domain-specific parameters.
+  // currently there is no additional parameters supported.
+  const [response] = await client.predict({
+    name: modelFullId,
+    payload: payload,
+    params: params,
+  });
+  console.log(`Prediction results:`);
+  response.payload.forEach(result => {
+    console.log(`Predicted class name: ${result.displayName}`);
+    console.log(`Predicted class score: ${result.classification.score}`);
+  });
+}
+
+```
+
+
+
+## Samples
+
+Samples are in the [`samples/`](https://github.com/googleapis/nodejs-automl/tree/master/samples) directory. The samples' `README.md`
+has instructions for running the samples.
+
+| Sample                      | Source Code                       | Try it |
+| --------------------------- | --------------------------------- | ------ |
+| Quickstart | [source code](https://github.com/googleapis/nodejs-automl/blob/master/samples/quickstart.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-automl&page=editor&open_in_editor=samples/quickstart.js,samples/README.md) |
+
+
+
+The [Cloud AutoML Node.js Client API Reference][client-docs] documentation
 also contains samples.
 
 ## Versioning
 
 This library follows [Semantic Versioning](http://semver.org/).
 
-This library is considered to be in **alpha**. This means it is still a
-work-in-progress and under active development. Any release is subject to
-backwards-incompatible changes at any time.
+
+
+This library is considered to be in **beta**. This means it is expected to be
+mostly stable while we work toward a general availability release; however,
+complete stability is not guaranteed. We will address issues and requests
+against beta libraries with a high priority.
+
+
+
 
 More Information: [Google Cloud Platform Launch Stages][launch_stages]
 
@@ -63,21 +153,10 @@ Apache Version 2.0
 
 See [LICENSE](https://github.com/googleapis/nodejs-automl/blob/master/LICENSE)
 
-## What's Next
-
-* [AutoML Documentation][product-docs]
-* [AutoML Node.js Client API Reference][client-docs]
-* [github.com/googleapis/nodejs-automl](https://github.com/googleapis/nodejs-automl)
-
-Read more about the client libraries for Cloud APIs, including the older
-Google APIs Client Libraries, in [Client Libraries Explained][explained].
-
-[explained]: https://cloud.google.com/apis/docs/client-libraries-explained
-
 [client-docs]: https://cloud.google.com/nodejs/docs/reference/automl/latest/
 [product-docs]: https://cloud.google.com/automl/docs/
 [shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
 [projects]: https://console.cloud.google.com/project
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
-[enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=automl
+[enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=automl.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/getting-started

--- a/package.json
+++ b/package.json
@@ -46,13 +46,13 @@
     "eslint-config-prettier": "^4.0.0",
     "eslint-plugin-node": "^9.0.0",
     "eslint-plugin-prettier": "^3.0.0",
-    "jsdoc-baseline": "git+https://github.com/hegemonic/jsdoc-baseline.git",
     "intelli-espower-loader": "^1.0.1",
     "jsdoc": "^3.5.5",
+    "jsdoc-baseline": "^0.1.0",
+    "linkinator": "^1.1.2",
     "mocha": "^6.0.0",
     "nyc": "^14.0.0",
     "power-assert": "^1.5.0",
-    "prettier": "^1.13.5",
-    "linkinator": "^1.1.2"
+    "prettier": "^1.13.5"
   }
 }

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,44 @@
+[//]: # "This README.md file is auto-generated, all changes to this file will be lost."
+[//]: # "To regenerate it, use `python -m synthtool`."
+<img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
+
+# [Cloud AutoML: Node.js Samples](https://github.com/googleapis/nodejs-automl)
+
+[![Open in Cloud Shell][shell_img]][shell_link]
+
+
+
+## Table of Contents
+
+* [Before you begin](#before-you-begin)
+* [Samples](#samples)
+  * [Quickstart](#quickstart)
+
+## Before you begin
+
+Before running the samples, make sure you've followed the steps outlined in
+[Using the client library](https://github.com/googleapis/nodejs-automl#using-the-client-library).
+
+## Samples
+
+
+
+### Quickstart
+
+View the [source code](https://github.com/googleapis/nodejs-automl/blob/master/samples/quickstart.js).
+
+[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-automl&page=editor&open_in_editor=samples/quickstart.js,samples/README.md)
+
+__Usage:__
+
+
+`node quickstart.js`
+
+
+
+
+
+
+[shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
+[shell_link]: https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-automl&page=editor&open_in_editor=samples/README.md
+[product-docs]: https://cloud.google.com/automl/docs/

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, Google, Inc.
+ * Copyright 2019, Google, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -16,6 +16,59 @@
 'use strict';
 
 // [START automl_quickstart]
-// TBD
-// [END automl_quickstart]
+async function main(
+  projectId,
+  computeRegion,
+  modelId,
+  filePath,
+  scoreThreshold
+) {
+  const automl = require('@google-cloud/automl');
+  const fs = require('fs');
 
+  // Create client for prediction service.
+  const client = new automl.PredictionServiceClient();
+
+  /**
+   * TODO(developer): Uncomment the following line before running the sample.
+   */
+  // const projectId = `The GCLOUD_PROJECT string, e.g. "my-gcloud-project"`;
+  // const computeRegion = `region-name, e.g. "us-central1"`;
+  // const modelId = `id of the model, e.g. “ICN723541179344731436”`;
+  // const filePath = `local text file path of content to be classified, e.g. "./resources/flower.png"`;
+  // const scoreThreshold = `value between 0.0 and 1.0, e.g. "0.5"`;
+
+  // Get the full path of the model.
+  const modelFullId = client.modelPath(projectId, computeRegion, modelId);
+
+  // Read the file content for prediction.
+  const content = fs.readFileSync(filePath, 'base64');
+
+  const params = {};
+
+  if (scoreThreshold) {
+    params.score_threshold = scoreThreshold;
+  }
+
+  // Set the payload by giving the content and type of the file.
+  const payload = {};
+  payload.image = {imageBytes: content};
+
+  // params is additional domain-specific parameters.
+  // currently there is no additional parameters supported.
+  const [response] = await client.predict({
+    name: modelFullId,
+    payload: payload,
+    params: params,
+  });
+  console.log(`Prediction results:`);
+  response.payload.forEach(result => {
+    console.log(`Predicted class name: ${result.displayName}`);
+    console.log(`Predicted class score: ${result.classification.score}`);
+  });
+}
+// [END automl_quickstart]
+main(...process.argv.slice(2)).catch(err => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -15,7 +15,6 @@
 
 'use strict';
 
-// [START automl_quickstart]
 async function main(
   projectId,
   computeRegion,
@@ -23,6 +22,7 @@ async function main(
   filePath,
   scoreThreshold
 ) {
+  // [START automl_quickstart]
   const automl = require('@google-cloud/automl');
   const fs = require('fs');
 
@@ -66,8 +66,8 @@ async function main(
     console.log(`Predicted class name: ${result.displayName}`);
     console.log(`Predicted class score: ${result.classification.score}`);
   });
+  // [END automl_quickstart]
 }
-// [END automl_quickstart]
 main(...process.argv.slice(2)).catch(err => {
   console.error(err);
   process.exitCode = 1;

--- a/samples/test/automlLanguageSentimentModel.v1beta1.test.js
+++ b/samples/test/automlLanguageSentimentModel.v1beta1.test.js
@@ -36,6 +36,9 @@ const undeployModelId = 'TST5013860858145102878';
 
 const exec = async cmd => (await execa.shell(cmd)).stdout;
 
+console.info('PROJECT_ID >>>');
+console.info(process.env.PROJECT_ID);
+
 describe.skip('Language Sentiment ModelAPI', () => {
   it(`should create  a model`, async () => {
     // Create model

--- a/samples/test/automlLanguageSentimentModel.v1beta1.test.js
+++ b/samples/test/automlLanguageSentimentModel.v1beta1.test.js
@@ -36,9 +36,6 @@ const undeployModelId = 'TST5013860858145102878';
 
 const exec = async cmd => (await execa.shell(cmd)).stdout;
 
-console.info('PROJECT_ID >>>');
-console.info(process.env.PROJECT_ID);
-
 describe.skip('Language Sentiment ModelAPI', () => {
   it(`should create  a model`, async () => {
     // Create model

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2019-05-22T21:22:35.295118Z",
+  "updateTime": "2019-05-22T22:20:23.138969Z",
   "sources": [
     {
       "generator": {

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2019-05-21T11:08:09.690003Z",
+  "updateTime": "2019-05-22T21:22:35.295118Z",
   "sources": [
     {
       "generator": {
@@ -12,15 +12,15 @@
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "32a10f69e2c9ce15bba13ab1ff928bacebb25160",
-        "internalRef": "249058354"
+        "sha": "f792303254ea54442d03ca470ffb38930bda7806",
+        "internalRef": "249516437"
       }
     },
     {
       "template": {
         "name": "node_library",
         "origin": "synthtool.gcp",
-        "version": "2019.5.2"
+        "version": "2019.4.10"
       }
     }
   ],


### PR DESCRIPTION
I would like to land `.repo-metdata.json` as a "feature", this will allow me to release a minor release of each library, generating documentation as a side effect.

I will hold off on landing these  PRs until I've performed a mass update adding the doc-site publication.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
