### PR TITLE
feat: added samples for api-endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ has instructions for running the samples.
 | Sample                      | Source Code                       | Try it |
 | --------------------------- | --------------------------------- | ------ |
 | Quickstart | [source code](https://github.com/googleapis/nodejs-automl/blob/master/samples/quickstart.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-automl&page=editor&open_in_editor=samples/quickstart.js,samples/README.md) |
+| Set Endpoint | [source code](https://github.com/googleapis/nodejs-automl/blob/master/samples/beta/setEndpoint.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-automl&page=editor&open_in_editor=samples/beta/setEndpoint.js,samples/README.md) |
 
 
 

--- a/linkinator.config.json
+++ b/linkinator.config.json
@@ -2,6 +2,7 @@
   "recurse": true,
   "skip": [
     "https://codecov.io/gh/googleapis/",
-    "www.googleapis.com"
+    "www.googleapis.com",
+    "setEndpoint.js"
   ]
 }

--- a/samples/README.md
+++ b/samples/README.md
@@ -13,6 +13,7 @@
 * [Before you begin](#before-you-begin)
 * [Samples](#samples)
   * [Quickstart](#quickstart)
+  * [Set Endpoint](#setEndpoint)
 
 ## Before you begin
 
@@ -33,6 +34,22 @@ __Usage:__
 
 
 `node quickstart.js`
+
+-----
+
+
+
+
+### Set Endpoint
+
+View the [source code](https://github.com/googleapis/nodejs-automl/blob/master/samples/beta/setEndpoint.js).
+
+[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-automl&page=editor&open_in_editor=samples/beta/setEndpoint.js,samples/README.md)
+
+__Usage:__
+
+
+`node setEndpoint.js`
 
 
 

--- a/samples/beta/setEndpoint.js
+++ b/samples/beta/setEndpoint.js
@@ -1,21 +1,20 @@
-/**
- * Copyright 2019, Google, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 'use strict';
 
-async function main(projectId) {
+async function setEndpoint(projectId) {
   // [START automl_set_endpoint]
   const automl = require('@google-cloud/automl').v1beta1;
 
@@ -42,7 +41,7 @@ async function main(projectId) {
   });
 }
 
-main(...process.argv.slice(2)).catch(err => {
+setEndpoint(...process.argv.slice(2)).catch(err => {
   console.error(err);
   process.exitCode = 1;
 });

--- a/samples/beta/setEndpoint.js
+++ b/samples/beta/setEndpoint.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2019, Google, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+async function main(projectId) {
+  // [START automl_set_endpoint]
+  const automl = require('@google-cloud/automl').v1beta1;
+
+  // You must first create a dataset, using the `eu` endpoint, before you can
+  // call other operations such as: list, get, import, delete, etc.
+  const clientOptions = {apiEndpoint: 'eu-automl.googleapis.com'};
+
+  // Instantiates a client
+  const client = new automl.AutoMlClient(clientOptions);
+
+  // A resource that represents Google Cloud Platform location.
+  const projectLocation = client.locationPath(projectId, 'eu');
+  // [END automl_set_endpoint]
+  console.log(projectLocation);
+
+  // Grabs the list of datasets in a given project location.
+  // Note: create a dataset in `eu` before calling `listDatasets`.
+  const responses = await client.listDatasets({parent: projectLocation});
+
+  // Prints out each dataset.
+  const datasets = responses[0];
+  datasets.forEach(dataset => {
+    console.log(dataset);
+  });
+}
+
+main(...process.argv.slice(2)).catch(err => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/samples/test/setEndpoint.test.js
+++ b/samples/test/setEndpoint.test.js
@@ -1,0 +1,29 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const {assert} = require('chai');
+const cp = require('child_process');
+
+const projectId = process.env.PROJECT_ID;
+
+const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
+
+describe('set endpoint for automl', () => {
+  it('should list all datasets in `eu`', async () => {
+    const stdout = execSync(`node beta/setEndpoint.js "${projectId}"`);
+    assert.match(stdout, /do_not_delete_eu/);
+  });
+});

--- a/samples/test/setEndpoint.test.js
+++ b/samples/test/setEndpoint.test.js
@@ -17,7 +17,7 @@
 const {assert} = require('chai');
 const cp = require('child_process');
 
-const projectId = process.env.PROJECT_ID;
+const projectId = process.env.GCLOUD_PROJECT;
 
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 


### PR DESCRIPTION
Adding code for api-endpoints sample. Style is to match Python canonical: https://github.com/GoogleCloudPlatform/python-docs-samples/blob/750d2f6d36b1a030f7226067922c8ac3dab3a39b/automl/beta/set_endpoint.py