### PR TITLE
test: deal with concurrent import

### DIFF
--- a/samples/test/import_dataset.test.js
+++ b/samples/test/import_dataset.test.js
@@ -118,7 +118,7 @@ describe('Automl Import Dataset Test', () => {
     assert.match(import_output, /Dataset imported/);
   });
 
-  it('should delete created dataset', async () => {
+  it('should delete created dataset', async function() {
     this.retries(5);
     await delay(this.test);
     const projectId = await client.getProjectId();

--- a/samples/test/import_dataset.test.js
+++ b/samples/test/import_dataset.test.js
@@ -60,7 +60,7 @@ describe('Automl Import Dataset Test', () => {
       try {
         const id = dataset.name
           .split('/')
-          [response.name.split('/').length - 1].split('\n')[0];
+          [dataset.name.split('/').length - 1].split('\n')[0];
         console.info(`checking dataset ${id}`);
         if (id.match(/test_[0-9a-f]{8}/)) {
           console.info(`deleting dataset ${id}`);

--- a/samples/test/import_dataset.test.js
+++ b/samples/test/import_dataset.test.js
@@ -69,7 +69,7 @@ describe('Automl Import Dataset Test', () => {
       [response.name.split('/').length - 1].split('\n')[0];
   });
 
-  it('should create, import, and delete a dataset', async () => {
+  it('should create, import, and delete a dataset', async function() {
     this.retries(5);
     await delay(this.test);
     const projectId = await client.getProjectId();


### PR DESCRIPTION
If two suites of tests happen to be running at the same time, this error can occur:

```
No other operations should be working on projects/1046198160504/*.
```
