### PR TITLE
feat: check status of long running operation by its name

### DIFF
--- a/src/v1/auto_ml_client.ts
+++ b/src/v1/auto_ml_client.ts
@@ -32,7 +32,7 @@ import {Transform} from 'stream';
 import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import * as gapicConfig from './auto_ml_client_config.json';
-
+import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -1074,6 +1074,42 @@ export class AutoMlClient {
     this.initialize();
     return this.innerApiCalls.createDataset(request, options, callback);
   }
+  /**
+   * Check the status of the long running operation returned by the createDataset() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkCreateDatasetProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkCreateDatasetProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.cloud.automl.v1.Dataset,
+      protos.google.cloud.automl.v1.OperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.createDataset,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.cloud.automl.v1.Dataset,
+      protos.google.cloud.automl.v1.OperationMetadata
+    >;
+  }
   deleteDataset(
     request: protos.google.cloud.automl.v1.IDeleteDatasetRequest,
     options?: gax.CallOptions
@@ -1175,6 +1211,42 @@ export class AutoMlClient {
     });
     this.initialize();
     return this.innerApiCalls.deleteDataset(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the deleteDataset() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkDeleteDatasetProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkDeleteDatasetProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1.OperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.deleteDataset,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1.OperationMetadata
+    >;
   }
   importData(
     request: protos.google.cloud.automl.v1.IImportDataRequest,
@@ -1286,6 +1358,42 @@ export class AutoMlClient {
     this.initialize();
     return this.innerApiCalls.importData(request, options, callback);
   }
+  /**
+   * Check the status of the long running operation returned by the importData() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkImportDataProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkImportDataProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1.OperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.importData,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1.OperationMetadata
+    >;
+  }
   exportData(
     request: protos.google.cloud.automl.v1.IExportDataRequest,
     options?: gax.CallOptions
@@ -1387,6 +1495,42 @@ export class AutoMlClient {
     });
     this.initialize();
     return this.innerApiCalls.exportData(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the exportData() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkExportDataProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkExportDataProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1.OperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.exportData,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1.OperationMetadata
+    >;
   }
   createModel(
     request: protos.google.cloud.automl.v1.ICreateModelRequest,
@@ -1492,6 +1636,42 @@ export class AutoMlClient {
     this.initialize();
     return this.innerApiCalls.createModel(request, options, callback);
   }
+  /**
+   * Check the status of the long running operation returned by the createModel() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkCreateModelProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkCreateModelProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.cloud.automl.v1.Model,
+      protos.google.cloud.automl.v1.OperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.createModel,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.cloud.automl.v1.Model,
+      protos.google.cloud.automl.v1.OperationMetadata
+    >;
+  }
   deleteModel(
     request: protos.google.cloud.automl.v1.IDeleteModelRequest,
     options?: gax.CallOptions
@@ -1593,6 +1773,42 @@ export class AutoMlClient {
     });
     this.initialize();
     return this.innerApiCalls.deleteModel(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the deleteModel() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkDeleteModelProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkDeleteModelProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1.OperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.deleteModel,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1.OperationMetadata
+    >;
   }
   deployModel(
     request: protos.google.cloud.automl.v1.IDeployModelRequest,
@@ -1707,6 +1923,42 @@ export class AutoMlClient {
     this.initialize();
     return this.innerApiCalls.deployModel(request, options, callback);
   }
+  /**
+   * Check the status of the long running operation returned by the deployModel() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkDeployModelProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkDeployModelProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1.OperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.deployModel,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1.OperationMetadata
+    >;
+  }
   undeployModel(
     request: protos.google.cloud.automl.v1.IUndeployModelRequest,
     options?: gax.CallOptions
@@ -1810,6 +2062,42 @@ export class AutoMlClient {
     });
     this.initialize();
     return this.innerApiCalls.undeployModel(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the undeployModel() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkUndeployModelProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkUndeployModelProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1.OperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.undeployModel,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1.OperationMetadata
+    >;
   }
   exportModel(
     request: protos.google.cloud.automl.v1.IExportModelRequest,
@@ -1916,6 +2204,42 @@ export class AutoMlClient {
     });
     this.initialize();
     return this.innerApiCalls.exportModel(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the exportModel() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkExportModelProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkExportModelProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1.OperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.exportModel,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1.OperationMetadata
+    >;
   }
   listDatasets(
     request: protos.google.cloud.automl.v1.IListDatasetsRequest,

--- a/src/v1/prediction_service_client.ts
+++ b/src/v1/prediction_service_client.ts
@@ -28,7 +28,7 @@ import * as path from 'path';
 
 import * as protos from '../../protos/protos';
 import * as gapicConfig from './prediction_service_client_config.json';
-
+import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -678,6 +678,42 @@ export class PredictionServiceClient {
     });
     this.initialize();
     return this.innerApiCalls.batchPredict(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the batchPredict() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkBatchPredictProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkBatchPredictProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.cloud.automl.v1.BatchPredictResult,
+      protos.google.cloud.automl.v1.OperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.batchPredict,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.cloud.automl.v1.BatchPredictResult,
+      protos.google.cloud.automl.v1.OperationMetadata
+    >;
   }
   // --------------------
   // -- Path templates --

--- a/src/v1beta1/auto_ml_client.ts
+++ b/src/v1beta1/auto_ml_client.ts
@@ -32,7 +32,7 @@ import {Transform} from 'stream';
 import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import * as gapicConfig from './auto_ml_client_config.json';
-
+import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -1480,6 +1480,42 @@ export class AutoMlClient {
     this.initialize();
     return this.innerApiCalls.deleteDataset(request, options, callback);
   }
+  /**
+   * Check the status of the long running operation returned by the deleteDataset() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkDeleteDatasetProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkDeleteDatasetProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1beta1.OperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.deleteDataset,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1beta1.OperationMetadata
+    >;
+  }
   importData(
     request: protos.google.cloud.automl.v1beta1.IImportDataRequest,
     options?: gax.CallOptions
@@ -1590,6 +1626,42 @@ export class AutoMlClient {
     this.initialize();
     return this.innerApiCalls.importData(request, options, callback);
   }
+  /**
+   * Check the status of the long running operation returned by the importData() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkImportDataProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkImportDataProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1beta1.OperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.importData,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1beta1.OperationMetadata
+    >;
+  }
   exportData(
     request: protos.google.cloud.automl.v1beta1.IExportDataRequest,
     options?: gax.CallOptions
@@ -1691,6 +1763,42 @@ export class AutoMlClient {
     });
     this.initialize();
     return this.innerApiCalls.exportData(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the exportData() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkExportDataProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkExportDataProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1beta1.OperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.exportData,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1beta1.OperationMetadata
+    >;
   }
   createModel(
     request: protos.google.cloud.automl.v1beta1.ICreateModelRequest,
@@ -1796,6 +1904,42 @@ export class AutoMlClient {
     this.initialize();
     return this.innerApiCalls.createModel(request, options, callback);
   }
+  /**
+   * Check the status of the long running operation returned by the createModel() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkCreateModelProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkCreateModelProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.cloud.automl.v1beta1.Model,
+      protos.google.cloud.automl.v1beta1.OperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.createModel,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.cloud.automl.v1beta1.Model,
+      protos.google.cloud.automl.v1beta1.OperationMetadata
+    >;
+  }
   deleteModel(
     request: protos.google.cloud.automl.v1beta1.IDeleteModelRequest,
     options?: gax.CallOptions
@@ -1897,6 +2041,42 @@ export class AutoMlClient {
     });
     this.initialize();
     return this.innerApiCalls.deleteModel(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the deleteModel() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkDeleteModelProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkDeleteModelProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1beta1.OperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.deleteModel,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1beta1.OperationMetadata
+    >;
   }
   deployModel(
     request: protos.google.cloud.automl.v1beta1.IDeployModelRequest,
@@ -2011,6 +2191,42 @@ export class AutoMlClient {
     this.initialize();
     return this.innerApiCalls.deployModel(request, options, callback);
   }
+  /**
+   * Check the status of the long running operation returned by the deployModel() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkDeployModelProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkDeployModelProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1beta1.OperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.deployModel,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1beta1.OperationMetadata
+    >;
+  }
   undeployModel(
     request: protos.google.cloud.automl.v1beta1.IUndeployModelRequest,
     options?: gax.CallOptions
@@ -2114,6 +2330,42 @@ export class AutoMlClient {
     });
     this.initialize();
     return this.innerApiCalls.undeployModel(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the undeployModel() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkUndeployModelProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkUndeployModelProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1beta1.OperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.undeployModel,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1beta1.OperationMetadata
+    >;
   }
   exportModel(
     request: protos.google.cloud.automl.v1beta1.IExportModelRequest,
@@ -2221,6 +2473,42 @@ export class AutoMlClient {
     });
     this.initialize();
     return this.innerApiCalls.exportModel(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the exportModel() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkExportModelProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkExportModelProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1beta1.OperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.exportModel,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1beta1.OperationMetadata
+    >;
   }
   exportEvaluatedExamples(
     request: protos.google.cloud.automl.v1beta1.IExportEvaluatedExamplesRequest,
@@ -2339,6 +2627,42 @@ export class AutoMlClient {
       options,
       callback
     );
+  }
+  /**
+   * Check the status of the long running operation returned by the exportEvaluatedExamples() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkExportEvaluatedExamplesProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkExportEvaluatedExamplesProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1beta1.OperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.exportEvaluatedExamples,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.protobuf.Empty,
+      protos.google.cloud.automl.v1beta1.OperationMetadata
+    >;
   }
   listDatasets(
     request: protos.google.cloud.automl.v1beta1.IListDatasetsRequest,

--- a/src/v1beta1/prediction_service_client.ts
+++ b/src/v1beta1/prediction_service_client.ts
@@ -28,7 +28,7 @@ import * as path from 'path';
 
 import * as protos from '../../protos/protos';
 import * as gapicConfig from './prediction_service_client_config.json';
-
+import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -639,6 +639,42 @@ export class PredictionServiceClient {
     });
     this.initialize();
     return this.innerApiCalls.batchPredict(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the batchPredict() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkBatchPredictProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkBatchPredictProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.cloud.automl.v1beta1.BatchPredictResult,
+      protos.google.cloud.automl.v1beta1.OperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.batchPredict,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.cloud.automl.v1beta1.BatchPredictResult,
+      protos.google.cloud.automl.v1beta1.OperationMetadata
+    >;
   }
   // --------------------
   // -- Path templates --

--- a/synth.metadata
+++ b/synth.metadata
@@ -3,23 +3,15 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/nodejs-automl.git",
-        "sha": "73c802577a5ed762e0bd285c6305d596f92f9550"
-      }
-    },
-    {
-      "git": {
-        "name": "googleapis",
-        "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "371206424e6db4df2cb3734bb1013dcaac9dbe4b",
-        "internalRef": "308716969"
+        "remote": "git@github.com:googleapis/nodejs-automl.git",
+        "sha": "35791ad2c4037bc5eeb69181ec40113c0f9860bc"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "19465d3ec5e5acdb01521d8f3bddd311bcbee28d"
+        "sha": "ab883569eb0257bbf16a6d825fd018b3adde3912"
       }
     }
   ],

--- a/test/gapic_auto_ml_v1.ts
+++ b/test/gapic_auto_ml_v1.ts
@@ -25,7 +25,7 @@ import * as automlModule from '../src';
 
 import {PassThrough} from 'stream';
 
-import {protobuf, LROperation} from 'google-gax';
+import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (instance.constructor as typeof protobuf.Message).toObject(
@@ -329,9 +329,7 @@ describe('v1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getDataset(request);
-      }, expectedError);
+      await assert.rejects(client.getDataset(request), expectedError);
       assert(
         (client.innerApiCalls.getDataset as SinonStub)
           .getCall(0)
@@ -446,9 +444,7 @@ describe('v1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateDataset(request);
-      }, expectedError);
+      await assert.rejects(client.updateDataset(request), expectedError);
       assert(
         (client.innerApiCalls.updateDataset as SinonStub)
           .getCall(0)
@@ -560,9 +556,7 @@ describe('v1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getAnnotationSpec(request);
-      }, expectedError);
+      await assert.rejects(client.getAnnotationSpec(request), expectedError);
       assert(
         (client.innerApiCalls.getAnnotationSpec as SinonStub)
           .getCall(0)
@@ -671,9 +665,7 @@ describe('v1.AutoMlClient', () => {
       };
       const expectedError = new Error('expected');
       client.innerApiCalls.getModel = stubSimpleCall(undefined, expectedError);
-      await assert.rejects(async () => {
-        await client.getModel(request);
-      }, expectedError);
+      await assert.rejects(client.getModel(request), expectedError);
       assert(
         (client.innerApiCalls.getModel as SinonStub)
           .getCall(0)
@@ -788,9 +780,7 @@ describe('v1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateModel(request);
-      }, expectedError);
+      await assert.rejects(client.updateModel(request), expectedError);
       assert(
         (client.innerApiCalls.updateModel as SinonStub)
           .getCall(0)
@@ -904,9 +894,7 @@ describe('v1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getModelEvaluation(request);
-      }, expectedError);
+      await assert.rejects(client.getModelEvaluation(request), expectedError);
       assert(
         (client.innerApiCalls.getModelEvaluation as SinonStub)
           .getCall(0)
@@ -1028,9 +1016,7 @@ describe('v1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createDataset(request);
-      }, expectedError);
+      await assert.rejects(client.createDataset(request), expectedError);
       assert(
         (client.innerApiCalls.createDataset as SinonStub)
           .getCall(0)
@@ -1063,14 +1049,53 @@ describe('v1.AutoMlClient', () => {
         expectedError
       );
       const [operation] = await client.createDataset(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.createDataset as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkCreateDatasetProgress without error', async () => {
+      const client = new automlModule.v1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkCreateDatasetProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkCreateDatasetProgress with error', async () => {
+      const client = new automlModule.v1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkCreateDatasetProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -1187,9 +1212,7 @@ describe('v1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteDataset(request);
-      }, expectedError);
+      await assert.rejects(client.deleteDataset(request), expectedError);
       assert(
         (client.innerApiCalls.deleteDataset as SinonStub)
           .getCall(0)
@@ -1222,14 +1245,53 @@ describe('v1.AutoMlClient', () => {
         expectedError
       );
       const [operation] = await client.deleteDataset(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.deleteDataset as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkDeleteDatasetProgress without error', async () => {
+      const client = new automlModule.v1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkDeleteDatasetProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkDeleteDatasetProgress with error', async () => {
+      const client = new automlModule.v1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkDeleteDatasetProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -1344,9 +1406,7 @@ describe('v1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.importData(request);
-      }, expectedError);
+      await assert.rejects(client.importData(request), expectedError);
       assert(
         (client.innerApiCalls.importData as SinonStub)
           .getCall(0)
@@ -1379,14 +1439,50 @@ describe('v1.AutoMlClient', () => {
         expectedError
       );
       const [operation] = await client.importData(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.importData as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkImportDataProgress without error', async () => {
+      const client = new automlModule.v1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkImportDataProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkImportDataProgress with error', async () => {
+      const client = new automlModule.v1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(client.checkImportDataProgress(''), expectedError);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -1501,9 +1597,7 @@ describe('v1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.exportData(request);
-      }, expectedError);
+      await assert.rejects(client.exportData(request), expectedError);
       assert(
         (client.innerApiCalls.exportData as SinonStub)
           .getCall(0)
@@ -1536,14 +1630,50 @@ describe('v1.AutoMlClient', () => {
         expectedError
       );
       const [operation] = await client.exportData(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.exportData as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkExportDataProgress without error', async () => {
+      const client = new automlModule.v1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkExportDataProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkExportDataProgress with error', async () => {
+      const client = new automlModule.v1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(client.checkExportDataProgress(''), expectedError);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -1658,9 +1788,7 @@ describe('v1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createModel(request);
-      }, expectedError);
+      await assert.rejects(client.createModel(request), expectedError);
       assert(
         (client.innerApiCalls.createModel as SinonStub)
           .getCall(0)
@@ -1693,14 +1821,50 @@ describe('v1.AutoMlClient', () => {
         expectedError
       );
       const [operation] = await client.createModel(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.createModel as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkCreateModelProgress without error', async () => {
+      const client = new automlModule.v1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkCreateModelProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkCreateModelProgress with error', async () => {
+      const client = new automlModule.v1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(client.checkCreateModelProgress(''), expectedError);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -1815,9 +1979,7 @@ describe('v1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteModel(request);
-      }, expectedError);
+      await assert.rejects(client.deleteModel(request), expectedError);
       assert(
         (client.innerApiCalls.deleteModel as SinonStub)
           .getCall(0)
@@ -1850,14 +2012,50 @@ describe('v1.AutoMlClient', () => {
         expectedError
       );
       const [operation] = await client.deleteModel(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.deleteModel as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkDeleteModelProgress without error', async () => {
+      const client = new automlModule.v1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkDeleteModelProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkDeleteModelProgress with error', async () => {
+      const client = new automlModule.v1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(client.checkDeleteModelProgress(''), expectedError);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -1972,9 +2170,7 @@ describe('v1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deployModel(request);
-      }, expectedError);
+      await assert.rejects(client.deployModel(request), expectedError);
       assert(
         (client.innerApiCalls.deployModel as SinonStub)
           .getCall(0)
@@ -2007,14 +2203,50 @@ describe('v1.AutoMlClient', () => {
         expectedError
       );
       const [operation] = await client.deployModel(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.deployModel as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkDeployModelProgress without error', async () => {
+      const client = new automlModule.v1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkDeployModelProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkDeployModelProgress with error', async () => {
+      const client = new automlModule.v1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(client.checkDeployModelProgress(''), expectedError);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -2131,9 +2363,7 @@ describe('v1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.undeployModel(request);
-      }, expectedError);
+      await assert.rejects(client.undeployModel(request), expectedError);
       assert(
         (client.innerApiCalls.undeployModel as SinonStub)
           .getCall(0)
@@ -2166,14 +2396,53 @@ describe('v1.AutoMlClient', () => {
         expectedError
       );
       const [operation] = await client.undeployModel(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.undeployModel as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkUndeployModelProgress without error', async () => {
+      const client = new automlModule.v1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkUndeployModelProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkUndeployModelProgress with error', async () => {
+      const client = new automlModule.v1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkUndeployModelProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -2288,9 +2557,7 @@ describe('v1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.exportModel(request);
-      }, expectedError);
+      await assert.rejects(client.exportModel(request), expectedError);
       assert(
         (client.innerApiCalls.exportModel as SinonStub)
           .getCall(0)
@@ -2323,14 +2590,50 @@ describe('v1.AutoMlClient', () => {
         expectedError
       );
       const [operation] = await client.exportModel(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.exportModel as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkExportModelProgress without error', async () => {
+      const client = new automlModule.v1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkExportModelProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkExportModelProgress with error', async () => {
+      const client = new automlModule.v1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(client.checkExportModelProgress(''), expectedError);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -2441,9 +2744,7 @@ describe('v1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listDatasets(request);
-      }, expectedError);
+      await assert.rejects(client.listDatasets(request), expectedError);
       assert(
         (client.innerApiCalls.listDatasets as SinonStub)
           .getCall(0)
@@ -2528,9 +2829,7 @@ describe('v1.AutoMlClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listDatasets.createStream as SinonStub)
           .getCall(0)
@@ -2729,9 +3028,7 @@ describe('v1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listModels(request);
-      }, expectedError);
+      await assert.rejects(client.listModels(request), expectedError);
       assert(
         (client.innerApiCalls.listModels as SinonStub)
           .getCall(0)
@@ -2815,9 +3112,7 @@ describe('v1.AutoMlClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listModels.createStream as SinonStub)
           .getCall(0)
@@ -3029,9 +3324,7 @@ describe('v1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listModelEvaluations(request);
-      }, expectedError);
+      await assert.rejects(client.listModelEvaluations(request), expectedError);
       assert(
         (client.innerApiCalls.listModelEvaluations as SinonStub)
           .getCall(0)
@@ -3128,9 +3421,7 @@ describe('v1.AutoMlClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listModelEvaluations.createStream as SinonStub)
           .getCall(0)

--- a/test/gapic_auto_ml_v1beta1.ts
+++ b/test/gapic_auto_ml_v1beta1.ts
@@ -25,7 +25,7 @@ import * as automlModule from '../src';
 
 import {PassThrough} from 'stream';
 
-import {protobuf, LROperation} from 'google-gax';
+import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (instance.constructor as typeof protobuf.Message).toObject(
@@ -329,9 +329,7 @@ describe('v1beta1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createDataset(request);
-      }, expectedError);
+      await assert.rejects(client.createDataset(request), expectedError);
       assert(
         (client.innerApiCalls.createDataset as SinonStub)
           .getCall(0)
@@ -443,9 +441,7 @@ describe('v1beta1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getDataset(request);
-      }, expectedError);
+      await assert.rejects(client.getDataset(request), expectedError);
       assert(
         (client.innerApiCalls.getDataset as SinonStub)
           .getCall(0)
@@ -560,9 +556,7 @@ describe('v1beta1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateDataset(request);
-      }, expectedError);
+      await assert.rejects(client.updateDataset(request), expectedError);
       assert(
         (client.innerApiCalls.updateDataset as SinonStub)
           .getCall(0)
@@ -674,9 +668,7 @@ describe('v1beta1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getAnnotationSpec(request);
-      }, expectedError);
+      await assert.rejects(client.getAnnotationSpec(request), expectedError);
       assert(
         (client.innerApiCalls.getAnnotationSpec as SinonStub)
           .getCall(0)
@@ -788,9 +780,7 @@ describe('v1beta1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getTableSpec(request);
-      }, expectedError);
+      await assert.rejects(client.getTableSpec(request), expectedError);
       assert(
         (client.innerApiCalls.getTableSpec as SinonStub)
           .getCall(0)
@@ -905,9 +895,7 @@ describe('v1beta1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateTableSpec(request);
-      }, expectedError);
+      await assert.rejects(client.updateTableSpec(request), expectedError);
       assert(
         (client.innerApiCalls.updateTableSpec as SinonStub)
           .getCall(0)
@@ -1019,9 +1007,7 @@ describe('v1beta1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getColumnSpec(request);
-      }, expectedError);
+      await assert.rejects(client.getColumnSpec(request), expectedError);
       assert(
         (client.innerApiCalls.getColumnSpec as SinonStub)
           .getCall(0)
@@ -1136,9 +1122,7 @@ describe('v1beta1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateColumnSpec(request);
-      }, expectedError);
+      await assert.rejects(client.updateColumnSpec(request), expectedError);
       assert(
         (client.innerApiCalls.updateColumnSpec as SinonStub)
           .getCall(0)
@@ -1247,9 +1231,7 @@ describe('v1beta1.AutoMlClient', () => {
       };
       const expectedError = new Error('expected');
       client.innerApiCalls.getModel = stubSimpleCall(undefined, expectedError);
-      await assert.rejects(async () => {
-        await client.getModel(request);
-      }, expectedError);
+      await assert.rejects(client.getModel(request), expectedError);
       assert(
         (client.innerApiCalls.getModel as SinonStub)
           .getCall(0)
@@ -1363,9 +1345,7 @@ describe('v1beta1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getModelEvaluation(request);
-      }, expectedError);
+      await assert.rejects(client.getModelEvaluation(request), expectedError);
       assert(
         (client.innerApiCalls.getModelEvaluation as SinonStub)
           .getCall(0)
@@ -1487,9 +1467,7 @@ describe('v1beta1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteDataset(request);
-      }, expectedError);
+      await assert.rejects(client.deleteDataset(request), expectedError);
       assert(
         (client.innerApiCalls.deleteDataset as SinonStub)
           .getCall(0)
@@ -1522,14 +1500,53 @@ describe('v1beta1.AutoMlClient', () => {
         expectedError
       );
       const [operation] = await client.deleteDataset(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.deleteDataset as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkDeleteDatasetProgress without error', async () => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkDeleteDatasetProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkDeleteDatasetProgress with error', async () => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkDeleteDatasetProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -1644,9 +1661,7 @@ describe('v1beta1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.importData(request);
-      }, expectedError);
+      await assert.rejects(client.importData(request), expectedError);
       assert(
         (client.innerApiCalls.importData as SinonStub)
           .getCall(0)
@@ -1679,14 +1694,50 @@ describe('v1beta1.AutoMlClient', () => {
         expectedError
       );
       const [operation] = await client.importData(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.importData as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkImportDataProgress without error', async () => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkImportDataProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkImportDataProgress with error', async () => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(client.checkImportDataProgress(''), expectedError);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -1801,9 +1852,7 @@ describe('v1beta1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.exportData(request);
-      }, expectedError);
+      await assert.rejects(client.exportData(request), expectedError);
       assert(
         (client.innerApiCalls.exportData as SinonStub)
           .getCall(0)
@@ -1836,14 +1885,50 @@ describe('v1beta1.AutoMlClient', () => {
         expectedError
       );
       const [operation] = await client.exportData(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.exportData as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkExportDataProgress without error', async () => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkExportDataProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkExportDataProgress with error', async () => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(client.checkExportDataProgress(''), expectedError);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -1958,9 +2043,7 @@ describe('v1beta1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createModel(request);
-      }, expectedError);
+      await assert.rejects(client.createModel(request), expectedError);
       assert(
         (client.innerApiCalls.createModel as SinonStub)
           .getCall(0)
@@ -1993,14 +2076,50 @@ describe('v1beta1.AutoMlClient', () => {
         expectedError
       );
       const [operation] = await client.createModel(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.createModel as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkCreateModelProgress without error', async () => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkCreateModelProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkCreateModelProgress with error', async () => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(client.checkCreateModelProgress(''), expectedError);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -2115,9 +2234,7 @@ describe('v1beta1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteModel(request);
-      }, expectedError);
+      await assert.rejects(client.deleteModel(request), expectedError);
       assert(
         (client.innerApiCalls.deleteModel as SinonStub)
           .getCall(0)
@@ -2150,14 +2267,50 @@ describe('v1beta1.AutoMlClient', () => {
         expectedError
       );
       const [operation] = await client.deleteModel(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.deleteModel as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkDeleteModelProgress without error', async () => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkDeleteModelProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkDeleteModelProgress with error', async () => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(client.checkDeleteModelProgress(''), expectedError);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -2272,9 +2425,7 @@ describe('v1beta1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deployModel(request);
-      }, expectedError);
+      await assert.rejects(client.deployModel(request), expectedError);
       assert(
         (client.innerApiCalls.deployModel as SinonStub)
           .getCall(0)
@@ -2307,14 +2458,50 @@ describe('v1beta1.AutoMlClient', () => {
         expectedError
       );
       const [operation] = await client.deployModel(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.deployModel as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkDeployModelProgress without error', async () => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkDeployModelProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkDeployModelProgress with error', async () => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(client.checkDeployModelProgress(''), expectedError);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -2431,9 +2618,7 @@ describe('v1beta1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.undeployModel(request);
-      }, expectedError);
+      await assert.rejects(client.undeployModel(request), expectedError);
       assert(
         (client.innerApiCalls.undeployModel as SinonStub)
           .getCall(0)
@@ -2466,14 +2651,53 @@ describe('v1beta1.AutoMlClient', () => {
         expectedError
       );
       const [operation] = await client.undeployModel(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.undeployModel as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkUndeployModelProgress without error', async () => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkUndeployModelProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkUndeployModelProgress with error', async () => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkUndeployModelProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -2588,9 +2812,7 @@ describe('v1beta1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.exportModel(request);
-      }, expectedError);
+      await assert.rejects(client.exportModel(request), expectedError);
       assert(
         (client.innerApiCalls.exportModel as SinonStub)
           .getCall(0)
@@ -2623,14 +2845,50 @@ describe('v1beta1.AutoMlClient', () => {
         expectedError
       );
       const [operation] = await client.exportModel(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.exportModel as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkExportModelProgress without error', async () => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkExportModelProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkExportModelProgress with error', async () => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(client.checkExportModelProgress(''), expectedError);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -2747,9 +3005,10 @@ describe('v1beta1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.exportEvaluatedExamples(request);
-      }, expectedError);
+      await assert.rejects(
+        client.exportEvaluatedExamples(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.exportEvaluatedExamples as SinonStub)
           .getCall(0)
@@ -2782,14 +3041,53 @@ describe('v1beta1.AutoMlClient', () => {
         expectedError
       );
       const [operation] = await client.exportEvaluatedExamples(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.exportEvaluatedExamples as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkExportEvaluatedExamplesProgress without error', async () => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkExportEvaluatedExamplesProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkExportEvaluatedExamplesProgress with error', async () => {
+      const client = new automlModule.v1beta1.AutoMlClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkExportEvaluatedExamplesProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -2900,9 +3198,7 @@ describe('v1beta1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listDatasets(request);
-      }, expectedError);
+      await assert.rejects(client.listDatasets(request), expectedError);
       assert(
         (client.innerApiCalls.listDatasets as SinonStub)
           .getCall(0)
@@ -2993,9 +3289,7 @@ describe('v1beta1.AutoMlClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listDatasets.createStream as SinonStub)
           .getCall(0)
@@ -3206,9 +3500,7 @@ describe('v1beta1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listTableSpecs(request);
-      }, expectedError);
+      await assert.rejects(client.listTableSpecs(request), expectedError);
       assert(
         (client.innerApiCalls.listTableSpecs as SinonStub)
           .getCall(0)
@@ -3305,9 +3597,7 @@ describe('v1beta1.AutoMlClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listTableSpecs.createStream as SinonStub)
           .getCall(0)
@@ -3524,9 +3814,7 @@ describe('v1beta1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listColumnSpecs(request);
-      }, expectedError);
+      await assert.rejects(client.listColumnSpecs(request), expectedError);
       assert(
         (client.innerApiCalls.listColumnSpecs as SinonStub)
           .getCall(0)
@@ -3623,9 +3911,7 @@ describe('v1beta1.AutoMlClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listColumnSpecs.createStream as SinonStub)
           .getCall(0)
@@ -3830,9 +4116,7 @@ describe('v1beta1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listModels(request);
-      }, expectedError);
+      await assert.rejects(client.listModels(request), expectedError);
       assert(
         (client.innerApiCalls.listModels as SinonStub)
           .getCall(0)
@@ -3922,9 +4206,7 @@ describe('v1beta1.AutoMlClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listModels.createStream as SinonStub)
           .getCall(0)
@@ -4138,9 +4420,7 @@ describe('v1beta1.AutoMlClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listModelEvaluations(request);
-      }, expectedError);
+      await assert.rejects(client.listModelEvaluations(request), expectedError);
       assert(
         (client.innerApiCalls.listModelEvaluations as SinonStub)
           .getCall(0)
@@ -4237,9 +4517,7 @@ describe('v1beta1.AutoMlClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listModelEvaluations.createStream as SinonStub)
           .getCall(0)

--- a/test/gapic_prediction_service_v1beta1.ts
+++ b/test/gapic_prediction_service_v1beta1.ts
@@ -23,7 +23,7 @@ import {SinonStub} from 'sinon';
 import {describe, it} from 'mocha';
 import * as predictionserviceModule from '../src';
 
-import {protobuf, LROperation} from 'google-gax';
+import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (instance.constructor as typeof protobuf.Message).toObject(
@@ -271,9 +271,7 @@ describe('v1beta1.PredictionServiceClient', () => {
       };
       const expectedError = new Error('expected');
       client.innerApiCalls.predict = stubSimpleCall(undefined, expectedError);
-      await assert.rejects(async () => {
-        await client.predict(request);
-      }, expectedError);
+      await assert.rejects(client.predict(request), expectedError);
       assert(
         (client.innerApiCalls.predict as SinonStub)
           .getCall(0)
@@ -399,9 +397,7 @@ describe('v1beta1.PredictionServiceClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.batchPredict(request);
-      }, expectedError);
+      await assert.rejects(client.batchPredict(request), expectedError);
       assert(
         (client.innerApiCalls.batchPredict as SinonStub)
           .getCall(0)
@@ -436,14 +432,54 @@ describe('v1beta1.PredictionServiceClient', () => {
         expectedError
       );
       const [operation] = await client.batchPredict(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.batchPredict as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkBatchPredictProgress without error', async () => {
+      const client = new predictionserviceModule.v1beta1.PredictionServiceClient(
+        {
+          credentials: {client_email: 'bogus', private_key: 'bogus'},
+          projectId: 'bogus',
+        }
+      );
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkBatchPredictProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkBatchPredictProgress with error', async () => {
+      const client = new predictionserviceModule.v1beta1.PredictionServiceClient(
+        {
+          credentials: {client_email: 'bogus', private_key: 'bogus'},
+          projectId: 'bogus',
+        }
+      );
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(client.checkBatchPredictProgress(''), expectedError);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 


### PR DESCRIPTION
For each client method returning a long running operation, a separate method to check its status is added.

Added methods: `checkBatchPredictProgress`, `checkCreateDatasetProgress`, `checkCreateModelProgress`, `checkDeleteDatasetProgress`, `checkDeleteModelProgress`, `checkDeployModelProgress`, `checkExportDataProgress`, `checkExportEvaluatedExamplesProgress`, `checkExportModelProgress`, `checkImportDataProgress`, `checkUndeployModelProgress`.