### PR TITLE
fix: Removed unneeded parse

### DIFF
--- a/samples/tables/predict.v1beta1.js
+++ b/samples/tables/predict.v1beta1.js
@@ -17,7 +17,7 @@ async function main(
   projectId = 'YOUR_GCP_PROJECT_ID',
   computeRegion = 'REGION',
   modelId = 'YOUR_MODEL_ID',
-  inputs = [{numberValue: 1}, {stringValue: 'value'}]
+  inputs = '[{"numberValue": 1}, {"stringValue": "value"}]'
 ) {
   // [START automl_tables_predict]
 


### PR DESCRIPTION
The arguments need to be strings as that's how the test passes them to the sample function.

Fixes https://b.corp.google.com/issues/174563161
