### PR TITLE
fix: Remove the json parse for inputs parameter

### DIFF
--- a/samples/tables/predict.v1beta1.js
+++ b/samples/tables/predict.v1beta1.js
@@ -19,6 +19,8 @@ async function main(
   modelId = 'YOUR_MODEL_ID',
   inputs = '[{"numberValue": 1}, {"stringValue": "value"}]'
 ) {
+  inputs = JSON.parse(inputs);
+
   // [START automl_tables_predict]
 
   /**
@@ -38,8 +40,6 @@ async function main(
 
   // Get the full path of the model.
   const modelFullId = automlClient.modelPath(projectId, computeRegion, modelId);
-
-  inputs = JSON.parse(inputs);
 
   async function predict() {
     // Set the payload by giving the row values.

--- a/samples/tables/predict.v1beta1.js
+++ b/samples/tables/predict.v1beta1.js
@@ -29,7 +29,7 @@ async function main(
   // const projectId = '[PROJECT_ID]' e.g., "my-gcloud-project";
   // const computeRegion = '[REGION_NAME]' e.g., "us-central1";
   // const modelId = '[MODEL_ID]' e.g., "TBL000000000000";
-  // const inputs = [{ numberValue: 1 }, { stringValue: 'value' }, { stringValue: 'value2' } ...]
+      // let inputs = JSON.stringify([{ numberValue: 1 }, { stringValue: 'value' }, { stringValue: 'value2' } ...])
 
   const automl = require('@google-cloud/automl');
 

--- a/samples/tables/predict.v1beta1.js
+++ b/samples/tables/predict.v1beta1.js
@@ -31,7 +31,7 @@ async function main(
   // const projectId = '[PROJECT_ID]' e.g., "my-gcloud-project";
   // const computeRegion = '[REGION_NAME]' e.g., "us-central1";
   // const modelId = '[MODEL_ID]' e.g., "TBL000000000000";
-      // let inputs = JSON.stringify([{ numberValue: 1 }, { stringValue: 'value' }, { stringValue: 'value2' } ...])
+  // const inputs = [{ numberValue: 1 }, { stringValue: 'value' }, { stringValue: 'value2' } ...]
 
   const automl = require('@google-cloud/automl');
 


### PR DESCRIPTION
This fixes an issue where if a particular line is uncommented and used then an error is thrown on the `JSON.parse(inputs)` line.

Fixes #581 
